### PR TITLE
Fe04 profile passwordchange step up verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "to-regex-range": "^5.0.1"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.9",
         "eslint": "^7.32.0",
         "tailwindcss": "3"
@@ -5200,6 +5202,61 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -5215,6 +5272,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.1",
@@ -8369,6 +8432,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -8476,6 +8548,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -14186,6 +14264,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.9",
     "eslint": "^7.32.0",
     "tailwindcss": "3"

--- a/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.css
+++ b/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.css
@@ -35,13 +35,36 @@
 }
 
 .cp-close-btn {
-  border: 1px solid #d1d5db;
-  background: #fff;
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  background: radial-gradient(circle at 28% 24%, #fff 0%, #fee2e2 64%, #fecaca 100%);
   border-radius: 999px;
-  width: 34px;
-  height: 34px;
-  font-size: 1.1rem;
+  width: 40px;
+  height: 40px;
+  color: #be123c;
+  box-shadow: 0 10px 18px rgba(190, 24, 93, 0.18);
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.cp-close-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(244, 63, 94, 0.45);
+  color: #9f1239;
+  box-shadow: 0 14px 24px rgba(190, 24, 93, 0.26);
+}
+
+.cp-close-btn svg {
+  width: 19px;
+  height: 19px;
+}
+
+.cp-close-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
 .cp-body {

--- a/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.css
+++ b/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.css
@@ -1,0 +1,254 @@
+.cp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 1600;
+}
+
+.cp-panel {
+  width: min(640px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  background: #fff;
+  border-radius: 16px;
+  border: 1px solid #dbe1ea;
+  box-shadow: 0 28px 56px rgba(2, 6, 23, 0.3);
+}
+
+.cp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.cp-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.cp-close-btn {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 999px;
+  width: 34px;
+  height: 34px;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.cp-body {
+  padding: 20px;
+}
+
+.cp-step-label {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.cp-subtitle {
+  margin: 8px 0 16px;
+  color: #334155;
+  font-size: 0.95rem;
+}
+
+.cp-form {
+  display: grid;
+  gap: 14px;
+}
+
+.cp-field {
+  display: grid;
+  gap: 6px;
+}
+
+.cp-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.cp-input-wrap {
+  display: flex;
+  align-items: center;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cp-field[data-state="focus"] .cp-input-wrap,
+.cp-field[data-state="typing"] .cp-input-wrap {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.cp-field[data-state="validation_error"] .cp-input-wrap,
+.cp-field[data-state="api_error"] .cp-input-wrap,
+.cp-field[data-state="rate_limited"] .cp-input-wrap {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+}
+
+.cp-field[data-state="loading"] .cp-input-wrap {
+  border-color: #4f46e5;
+}
+
+.cp-field[data-state="success"] .cp-input-wrap {
+  border-color: #059669;
+}
+
+.cp-input {
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 12px 14px;
+  font-size: 0.95rem;
+  color: #111827;
+}
+
+.cp-toggle {
+  border: none;
+  background: transparent;
+  padding: 8px 10px;
+  cursor: pointer;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cp-field-error {
+  font-size: 0.8rem;
+  color: #dc2626;
+}
+
+.cp-feedback {
+  margin-top: 2px;
+  font-size: 0.88rem;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.cp-feedback.api_error,
+.cp-feedback.validation_error {
+  color: #991b1b;
+  background: #fef2f2;
+}
+
+.cp-feedback.rate_limited {
+  color: #92400e;
+  background: #fffbeb;
+}
+
+.cp-feedback.success {
+  color: #065f46;
+  background: #ecfdf5;
+}
+
+.cp-guidance {
+  margin-top: 6px;
+  font-size: 0.82rem;
+  color: #475569;
+}
+
+.cp-checklist {
+  margin: 4px 0 0;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: #f8fafc;
+  padding: 10px 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.cp-check-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.86rem;
+  color: #475569;
+}
+
+.cp-check-item.passed {
+  color: #047857;
+}
+
+.cp-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.cp-btn {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cp-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cp-btn-primary {
+  background: #1d4ed8;
+  color: #fff;
+}
+
+.cp-btn-secondary {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.cp-flow-state {
+  margin-top: 14px;
+  font-size: 0.78rem;
+  color: #64748b;
+}
+
+.cp-success-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: #dcfce7;
+  color: #166534;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.3rem;
+  margin-bottom: 8px;
+}
+
+@media (max-width: 640px) {
+  .cp-header {
+    padding: 14px 14px;
+  }
+
+  .cp-body {
+    padding: 14px;
+  }
+
+  .cp-actions {
+    flex-direction: column;
+  }
+
+  .cp-btn {
+    width: 100%;
+  }
+}

--- a/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.jsx
+++ b/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useReducer, useRef } from "react";
-import { CheckCircle2, Circle, Eye, EyeOff } from "lucide-react";
+import { CheckCircle2, Circle, Eye, EyeOff, X } from "lucide-react";
 import {
   PASSWORD_RULES,
   getPasswordChecklist,
@@ -858,7 +858,7 @@ const ChangePasswordModal = ({
             disabled={state.isLoading}
             aria-label="Close change password modal"
           >
-            ×
+            <X size={18} strokeWidth={2.5} />
           </button>
         </div>
 

--- a/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.jsx
+++ b/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.jsx
@@ -1,0 +1,879 @@
+import React, { useEffect, useMemo, useReducer, useRef } from "react";
+import { CheckCircle2, Circle, Eye, EyeOff } from "lucide-react";
+import {
+  PASSWORD_RULES,
+  getPasswordChecklist,
+  isPasswordStrong,
+  mapPasswordApiError,
+  validateUpdateStep,
+  validateVerifyStep,
+} from "./changePasswordValidation";
+import { changePasswordApi } from "./changePasswordApi";
+import "./ChangePasswordModal.css";
+
+const FLOW_STEP = {
+  VERIFY: "verify",
+  UPDATE: "update",
+  SUCCESS: "success",
+};
+
+const FLOW_STATUS = {
+  DEFAULT: "default",
+  FOCUS: "focus",
+  TYPING: "typing",
+  VALIDATION_ERROR: "validation_error",
+  API_ERROR: "api_error",
+  LOADING: "loading",
+  SUCCESS: "success",
+  RATE_LIMITED: "rate_limited",
+};
+
+const createInitialState = () => ({
+  step: FLOW_STEP.VERIFY,
+  flowStatus: FLOW_STATUS.DEFAULT,
+  isLoading: false,
+  currentPassword: "",
+  newPassword: "",
+  confirmPassword: "",
+  showCurrentPassword: false,
+  showNewPassword: false,
+  showConfirmPassword: false,
+  fieldErrors: {
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  },
+  fieldStates: {
+    currentPassword: FLOW_STATUS.DEFAULT,
+    newPassword: FLOW_STATUS.DEFAULT,
+    confirmPassword: FLOW_STATUS.DEFAULT,
+  },
+  formError: "",
+  retryGuidance: "",
+});
+
+const applyErrorStates = (state, fieldErrors, fallbackState) => {
+  const next = { ...state.fieldStates };
+
+  Object.keys(next).forEach((field) => {
+    next[field] = fieldErrors[field] ? fallbackState : state.fieldStates[field];
+  });
+
+  return next;
+};
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case "RESET":
+      return createInitialState();
+
+    case "FIELD_FOCUS": {
+      if (state.isLoading) return state;
+      const nextFieldStates = {
+        ...state.fieldStates,
+        [action.field]: FLOW_STATUS.FOCUS,
+      };
+      return {
+        ...state,
+        fieldStates: nextFieldStates,
+        flowStatus: FLOW_STATUS.FOCUS,
+      };
+    }
+
+    case "FIELD_BLUR": {
+      const value = state[action.field] || "";
+      if (value || state.fieldErrors[action.field]) return state;
+
+      return {
+        ...state,
+        fieldStates: {
+          ...state.fieldStates,
+          [action.field]: FLOW_STATUS.DEFAULT,
+        },
+      };
+    }
+
+    case "FIELD_CHANGE": {
+      return {
+        ...state,
+        [action.field]: action.value,
+        flowStatus: FLOW_STATUS.TYPING,
+        fieldErrors: {
+          ...state.fieldErrors,
+          [action.field]: "",
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          [action.field]: FLOW_STATUS.TYPING,
+        },
+        formError: "",
+        retryGuidance: "",
+      };
+    }
+
+    case "TOGGLE_VISIBILITY": {
+      return {
+        ...state,
+        [action.field]: !state[action.field],
+      };
+    }
+
+    case "VERIFY_VALIDATION_ERROR": {
+      return {
+        ...state,
+        isLoading: false,
+        flowStatus: FLOW_STATUS.VALIDATION_ERROR,
+        fieldErrors: {
+          ...state.fieldErrors,
+          ...action.fieldErrors,
+        },
+        fieldStates: applyErrorStates(
+          state,
+          action.fieldErrors,
+          FLOW_STATUS.VALIDATION_ERROR
+        ),
+        formError: action.formError || "",
+        retryGuidance: action.retryGuidance || "",
+      };
+    }
+
+    case "VERIFY_REQUEST": {
+      return {
+        ...state,
+        isLoading: true,
+        flowStatus: FLOW_STATUS.LOADING,
+        fieldErrors: {
+          ...state.fieldErrors,
+          currentPassword: "",
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          currentPassword: FLOW_STATUS.LOADING,
+        },
+        formError: "",
+        retryGuidance: "",
+      };
+    }
+
+    case "VERIFY_FAILURE": {
+      const flowStatus = action.flowStatus || FLOW_STATUS.API_ERROR;
+      return {
+        ...state,
+        isLoading: false,
+        flowStatus,
+        fieldErrors: {
+          ...state.fieldErrors,
+          ...action.fieldErrors,
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          currentPassword: action.fieldErrors?.currentPassword
+            ? flowStatus
+            : state.fieldStates.currentPassword,
+        },
+        formError: action.formError || "",
+        retryGuidance: action.retryGuidance || "",
+      };
+    }
+
+    case "VERIFY_SUCCESS": {
+      return {
+        ...state,
+        step: FLOW_STEP.UPDATE,
+        isLoading: false,
+        flowStatus: FLOW_STATUS.SUCCESS,
+        fieldErrors: {
+          ...state.fieldErrors,
+          currentPassword: "",
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          currentPassword: FLOW_STATUS.SUCCESS,
+          newPassword: FLOW_STATUS.DEFAULT,
+          confirmPassword: FLOW_STATUS.DEFAULT,
+        },
+        formError: "",
+        retryGuidance: "",
+      };
+    }
+
+    case "BACK_TO_VERIFY": {
+      return {
+        ...state,
+        step: FLOW_STEP.VERIFY,
+        flowStatus: FLOW_STATUS.DEFAULT,
+        isLoading: false,
+        newPassword: "",
+        confirmPassword: "",
+        fieldErrors: {
+          ...state.fieldErrors,
+          newPassword: "",
+          confirmPassword: "",
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          newPassword: FLOW_STATUS.DEFAULT,
+          confirmPassword: FLOW_STATUS.DEFAULT,
+        },
+        formError: "",
+        retryGuidance: "",
+      };
+    }
+
+    case "UPDATE_VALIDATION_ERROR": {
+      return {
+        ...state,
+        isLoading: false,
+        flowStatus: FLOW_STATUS.VALIDATION_ERROR,
+        fieldErrors: {
+          ...state.fieldErrors,
+          ...action.fieldErrors,
+        },
+        fieldStates: applyErrorStates(
+          state,
+          action.fieldErrors,
+          FLOW_STATUS.VALIDATION_ERROR
+        ),
+        formError: action.formError || "",
+        retryGuidance: action.retryGuidance || "",
+      };
+    }
+
+    case "UPDATE_REQUEST": {
+      return {
+        ...state,
+        isLoading: true,
+        flowStatus: FLOW_STATUS.LOADING,
+        fieldErrors: {
+          ...state.fieldErrors,
+          newPassword: "",
+          confirmPassword: "",
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          newPassword: FLOW_STATUS.LOADING,
+          confirmPassword: FLOW_STATUS.LOADING,
+        },
+        formError: "",
+        retryGuidance: "",
+      };
+    }
+
+    case "UPDATE_FAILURE": {
+      const flowStatus = action.flowStatus || FLOW_STATUS.API_ERROR;
+
+      return {
+        ...state,
+        isLoading: false,
+        flowStatus,
+        fieldErrors: {
+          ...state.fieldErrors,
+          ...action.fieldErrors,
+        },
+        fieldStates: {
+          ...state.fieldStates,
+          newPassword: action.fieldErrors?.newPassword
+            ? flowStatus
+            : state.fieldStates.newPassword,
+          confirmPassword: action.fieldErrors?.confirmPassword
+            ? flowStatus
+            : state.fieldStates.confirmPassword,
+          currentPassword: action.fieldErrors?.currentPassword
+            ? flowStatus
+            : state.fieldStates.currentPassword,
+        },
+        formError: action.formError || "",
+        retryGuidance: action.retryGuidance || "",
+      };
+    }
+
+    case "UPDATE_SUCCESS": {
+      return {
+        ...state,
+        step: FLOW_STEP.SUCCESS,
+        isLoading: false,
+        flowStatus: FLOW_STATUS.SUCCESS,
+        fieldErrors: {
+          currentPassword: "",
+          newPassword: "",
+          confirmPassword: "",
+        },
+        fieldStates: {
+          currentPassword: FLOW_STATUS.SUCCESS,
+          newPassword: FLOW_STATUS.SUCCESS,
+          confirmPassword: FLOW_STATUS.SUCCESS,
+        },
+        formError:
+          action.formError ||
+          "Password updated successfully. Redirecting you to login for security.",
+        retryGuidance: "",
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+const getFeedbackClass = (flowStatus) => {
+  if (flowStatus === FLOW_STATUS.RATE_LIMITED) return "rate_limited";
+  if (flowStatus === FLOW_STATUS.SUCCESS) return "success";
+  if (flowStatus === FLOW_STATUS.VALIDATION_ERROR) return "validation_error";
+  return "api_error";
+};
+
+const focusableSelector = [
+  'button:not([disabled])',
+  'input:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+const normalizeApiResult = (result) => {
+  if (!result || typeof result !== "object") {
+    return { ok: false, status: 500, data: { message: "Invalid API response" } };
+  }
+
+  return {
+    ok: Boolean(result.ok),
+    status: Number(result.status || 0),
+    data: result.data || {},
+  };
+};
+
+const ChangePasswordModal = ({
+  isOpen,
+  onRequestClose,
+  userId,
+  authToken,
+  onPasswordUpdated,
+  onSessionExpired,
+  apiClient = changePasswordApi,
+}) => {
+  const [state, dispatch] = useReducer(reducer, undefined, createInitialState);
+
+  const modalRef = useRef(null);
+  const currentPasswordRef = useRef(null);
+  const newPasswordRef = useRef(null);
+
+  const checklist = useMemo(
+    () => getPasswordChecklist(state.newPassword),
+    [state.newPassword]
+  );
+
+  const isUpdateFormValid = useMemo(() => {
+    const errors = validateUpdateStep({
+      currentPassword: state.currentPassword,
+      newPassword: state.newPassword,
+      confirmPassword: state.confirmPassword,
+    });
+    return Object.keys(errors).length === 0 && isPasswordStrong(checklist);
+  }, [checklist, state.confirmPassword, state.currentPassword, state.newPassword]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    dispatch({ type: "RESET" });
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previousActiveElement = document.activeElement;
+
+    const focusTimer = window.setTimeout(() => {
+      if (state.step === FLOW_STEP.VERIFY) {
+        currentPasswordRef.current?.focus();
+      } else if (state.step === FLOW_STEP.UPDATE) {
+        newPasswordRef.current?.focus();
+      }
+    }, 0);
+
+    const handleKeyDown = (event) => {
+      if (!modalRef.current) return;
+
+      if (event.key === "Escape" && !state.isLoading) {
+        event.preventDefault();
+        onRequestClose?.();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = Array.from(
+        modalRef.current.querySelectorAll(focusableSelector)
+      );
+
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener("keydown", handleKeyDown);
+      if (previousActiveElement && typeof previousActiveElement.focus === "function") {
+        previousActiveElement.focus();
+      }
+    };
+  }, [isOpen, onRequestClose, state.isLoading, state.step]);
+
+  if (!isOpen) return null;
+
+  const handleVerifySubmit = async (event) => {
+    event.preventDefault();
+
+    const validationErrors = validateVerifyStep(state.currentPassword);
+
+    if (Object.keys(validationErrors).length > 0) {
+      dispatch({
+        type: "VERIFY_VALIDATION_ERROR",
+        flowStatus: FLOW_STATUS.VALIDATION_ERROR,
+        fieldErrors: validationErrors,
+      });
+      return;
+    }
+
+    if (!userId) {
+      dispatch({
+        type: "VERIFY_FAILURE",
+        flowStatus: FLOW_STATUS.API_ERROR,
+        fieldErrors: {},
+        formError: "Unable to identify your account. Please sign in again.",
+        retryGuidance: "Refresh the page or log in again and retry.",
+      });
+      return;
+    }
+
+    dispatch({ type: "VERIFY_REQUEST" });
+
+    try {
+      const rawResult = await apiClient.verifyCurrentPassword({
+        userId,
+        currentPassword: state.currentPassword,
+        token: authToken,
+      });
+      const result = normalizeApiResult(rawResult);
+
+      if (result.ok) {
+        dispatch({ type: "VERIFY_SUCCESS" });
+        return;
+      }
+
+      const mappedError = mapPasswordApiError({
+        status: result.status,
+        data: result.data,
+        step: FLOW_STEP.VERIFY,
+      });
+
+      dispatch({
+        type: "VERIFY_FAILURE",
+        ...mappedError,
+      });
+
+      if (mappedError.shouldRedirectToLogin && typeof onSessionExpired === "function") {
+        onSessionExpired(mappedError.formError);
+      }
+    } catch (_error) {
+      dispatch({
+        type: "VERIFY_FAILURE",
+        flowStatus: FLOW_STATUS.API_ERROR,
+        fieldErrors: {},
+        formError: "Network error while verifying current password.",
+        retryGuidance: "Check your connection and try again.",
+      });
+    }
+  };
+
+  const handleUpdateSubmit = async (event) => {
+    event.preventDefault();
+
+    const validationErrors = validateUpdateStep({
+      currentPassword: state.currentPassword,
+      newPassword: state.newPassword,
+      confirmPassword: state.confirmPassword,
+    });
+
+    if (Object.keys(validationErrors).length > 0) {
+      dispatch({
+        type: "UPDATE_VALIDATION_ERROR",
+        fieldErrors: validationErrors,
+      });
+      return;
+    }
+
+    dispatch({ type: "UPDATE_REQUEST" });
+
+    try {
+      const rawResult = await apiClient.updatePassword({
+        userId,
+        currentPassword: state.currentPassword,
+        newPassword: state.newPassword,
+        token: authToken,
+      });
+      const result = normalizeApiResult(rawResult);
+
+      if (result.ok) {
+        dispatch({ type: "UPDATE_SUCCESS" });
+
+        if (typeof onPasswordUpdated === "function") {
+          await new Promise((resolve) => window.setTimeout(resolve, 400));
+          await onPasswordUpdated();
+        }
+
+        return;
+      }
+
+      const mappedError = mapPasswordApiError({
+        status: result.status,
+        data: result.data,
+        step: FLOW_STEP.UPDATE,
+      });
+
+      dispatch({
+        type: "UPDATE_FAILURE",
+        ...mappedError,
+      });
+
+      if (mappedError.shouldRedirectToLogin && typeof onSessionExpired === "function") {
+        onSessionExpired(mappedError.formError);
+      }
+    } catch (_error) {
+      dispatch({
+        type: "UPDATE_FAILURE",
+        flowStatus: FLOW_STATUS.API_ERROR,
+        fieldErrors: {},
+        formError: "Network error while updating password.",
+        retryGuidance: "Check your connection and try again.",
+      });
+    }
+  };
+
+  const renderVerifyStep = () => {
+    const verifyDisabled = state.isLoading || !state.currentPassword.trim();
+
+    return (
+      <form className="cp-form" onSubmit={handleVerifySubmit} noValidate>
+        <p className="cp-step-label">Step 1 of 2</p>
+        <p className="cp-subtitle">
+          Verify your current password to continue.
+        </p>
+
+        <div
+          className="cp-field"
+          data-state={state.fieldStates.currentPassword}
+        >
+          <label className="cp-label" htmlFor="cp-current-password">
+            Current Password
+          </label>
+          <div className="cp-input-wrap">
+            <input
+              ref={currentPasswordRef}
+              id="cp-current-password"
+              name="currentPassword"
+              className="cp-input"
+              type={state.showCurrentPassword ? "text" : "password"}
+              value={state.currentPassword}
+              onFocus={() => dispatch({ type: "FIELD_FOCUS", field: "currentPassword" })}
+              onBlur={() => dispatch({ type: "FIELD_BLUR", field: "currentPassword" })}
+              onChange={(event) =>
+                dispatch({
+                  type: "FIELD_CHANGE",
+                  field: "currentPassword",
+                  value: event.target.value,
+                })
+              }
+              aria-label="Current Password"
+              aria-invalid={Boolean(state.fieldErrors.currentPassword)}
+              aria-describedby={
+                state.fieldErrors.currentPassword ? "cp-current-password-error" : undefined
+              }
+              autoComplete="current-password"
+            />
+            <button
+              type="button"
+              className="cp-toggle"
+              onClick={() =>
+                dispatch({
+                  type: "TOGGLE_VISIBILITY",
+                  field: "showCurrentPassword",
+                })
+              }
+              aria-label={
+                state.showCurrentPassword ? "Hide current password" : "Show current password"
+              }
+            >
+              {state.showCurrentPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          {state.fieldErrors.currentPassword && (
+            <div id="cp-current-password-error" className="cp-field-error">
+              {state.fieldErrors.currentPassword}
+            </div>
+          )}
+        </div>
+
+        {state.formError && (
+          <div className={`cp-feedback ${getFeedbackClass(state.flowStatus)}`} role="alert">
+            {state.formError}
+            {state.retryGuidance ? (
+              <div className="cp-guidance">{state.retryGuidance}</div>
+            ) : null}
+          </div>
+        )}
+        {!state.formError && state.retryGuidance ? (
+          <div className="cp-guidance" role="note">
+            {state.retryGuidance}
+          </div>
+        ) : null}
+
+        <div className="cp-actions">
+          <button
+            type="button"
+            className="cp-btn cp-btn-secondary"
+            onClick={onRequestClose}
+            disabled={state.isLoading}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="cp-btn cp-btn-primary"
+            disabled={verifyDisabled}
+          >
+            {state.isLoading ? "Verifying..." : "Verify"}
+          </button>
+        </div>
+      </form>
+    );
+  };
+
+  const renderUpdateStep = () => {
+    const updateDisabled = state.isLoading || !isUpdateFormValid;
+
+    return (
+      <form className="cp-form" onSubmit={handleUpdateSubmit} noValidate>
+        <p className="cp-step-label">Step 2 of 2</p>
+        <p className="cp-subtitle">
+          Set your new password and confirm it before update.
+        </p>
+
+        <div className="cp-field" data-state={state.fieldStates.newPassword}>
+          <label className="cp-label" htmlFor="cp-new-password">
+            New Password
+          </label>
+          <div className="cp-input-wrap">
+            <input
+              ref={newPasswordRef}
+              id="cp-new-password"
+              name="newPassword"
+              className="cp-input"
+              type={state.showNewPassword ? "text" : "password"}
+              value={state.newPassword}
+              onFocus={() => dispatch({ type: "FIELD_FOCUS", field: "newPassword" })}
+              onBlur={() => dispatch({ type: "FIELD_BLUR", field: "newPassword" })}
+              onChange={(event) =>
+                dispatch({
+                  type: "FIELD_CHANGE",
+                  field: "newPassword",
+                  value: event.target.value,
+                })
+              }
+              aria-label="New Password"
+              autoComplete="new-password"
+              aria-invalid={Boolean(state.fieldErrors.newPassword)}
+              aria-describedby={
+                state.fieldErrors.newPassword ? "cp-new-password-error" : undefined
+              }
+            />
+            <button
+              type="button"
+              className="cp-toggle"
+              onClick={() =>
+                dispatch({
+                  type: "TOGGLE_VISIBILITY",
+                  field: "showNewPassword",
+                })
+              }
+              aria-label={state.showNewPassword ? "Hide new password" : "Show new password"}
+            >
+              {state.showNewPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          {state.fieldErrors.newPassword && (
+            <div id="cp-new-password-error" className="cp-field-error">
+              {state.fieldErrors.newPassword}
+            </div>
+          )}
+        </div>
+
+        <div className="cp-checklist" aria-live="polite">
+          {PASSWORD_RULES.map((rule) => {
+            const passed = checklist[rule.key];
+            return (
+              <div
+                key={rule.key}
+                className={`cp-check-item ${passed ? "passed" : ""}`}
+              >
+                {passed ? <CheckCircle2 size={14} /> : <Circle size={14} />}
+                <span>{rule.label}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="cp-field" data-state={state.fieldStates.confirmPassword}>
+          <label className="cp-label" htmlFor="cp-confirm-password">
+            Confirm New Password
+          </label>
+          <div className="cp-input-wrap">
+            <input
+              id="cp-confirm-password"
+              name="confirmPassword"
+              className="cp-input"
+              type={state.showConfirmPassword ? "text" : "password"}
+              value={state.confirmPassword}
+              onFocus={() => dispatch({ type: "FIELD_FOCUS", field: "confirmPassword" })}
+              onBlur={() => dispatch({ type: "FIELD_BLUR", field: "confirmPassword" })}
+              onChange={(event) =>
+                dispatch({
+                  type: "FIELD_CHANGE",
+                  field: "confirmPassword",
+                  value: event.target.value,
+                })
+              }
+              aria-label="Confirm New Password"
+              autoComplete="new-password"
+              aria-invalid={Boolean(state.fieldErrors.confirmPassword)}
+              aria-describedby={
+                state.fieldErrors.confirmPassword ? "cp-confirm-password-error" : undefined
+              }
+            />
+            <button
+              type="button"
+              className="cp-toggle"
+              onClick={() =>
+                dispatch({
+                  type: "TOGGLE_VISIBILITY",
+                  field: "showConfirmPassword",
+                })
+              }
+              aria-label={
+                state.showConfirmPassword
+                  ? "Hide confirm password"
+                  : "Show confirm password"
+              }
+            >
+              {state.showConfirmPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          {state.fieldErrors.confirmPassword && (
+            <div id="cp-confirm-password-error" className="cp-field-error">
+              {state.fieldErrors.confirmPassword}
+            </div>
+          )}
+        </div>
+
+        {state.formError && (
+          <div className={`cp-feedback ${getFeedbackClass(state.flowStatus)}`} role="alert">
+            {state.formError}
+            {state.retryGuidance ? (
+              <div className="cp-guidance">{state.retryGuidance}</div>
+            ) : null}
+          </div>
+        )}
+        {!state.formError && state.retryGuidance ? (
+          <div className="cp-guidance" role="note">
+            {state.retryGuidance}
+          </div>
+        ) : null}
+
+        <div className="cp-actions">
+          <button
+            type="button"
+            className="cp-btn cp-btn-secondary"
+            onClick={() => dispatch({ type: "BACK_TO_VERIFY" })}
+            disabled={state.isLoading}
+          >
+            Back
+          </button>
+          <button
+            type="submit"
+            className="cp-btn cp-btn-primary"
+            disabled={updateDisabled}
+          >
+            {state.isLoading ? "Updating..." : "Update Password"}
+          </button>
+        </div>
+      </form>
+    );
+  };
+
+  const renderSuccessStep = () => (
+    <div>
+      <div className="cp-success-icon" aria-hidden="true">
+        ✓
+      </div>
+      <p className="cp-step-label">Password Updated</p>
+      <p className="cp-subtitle">{state.formError}</p>
+    </div>
+  );
+
+  return (
+    <div
+      className="cp-overlay"
+      aria-hidden={false}
+      onMouseDown={() => {
+        if (!state.isLoading) onRequestClose?.();
+      }}
+    >
+      <div
+        className="cp-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cp-modal-title"
+        ref={modalRef}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="cp-header">
+          <h3 id="cp-modal-title" className="cp-title">
+            Change Password
+          </h3>
+          <button
+            type="button"
+            className="cp-close-btn"
+            onClick={onRequestClose}
+            disabled={state.isLoading}
+            aria-label="Close change password modal"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="cp-body">
+          {state.step === FLOW_STEP.VERIFY ? renderVerifyStep() : null}
+          {state.step === FLOW_STEP.UPDATE ? renderUpdateStep() : null}
+          {state.step === FLOW_STEP.SUCCESS ? renderSuccessStep() : null}
+
+          <div className="cp-flow-state" aria-live="polite">
+            Runtime state: {state.flowStatus.replace("_", " ")}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChangePasswordModal;

--- a/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.test.jsx
+++ b/src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.test.jsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ChangePasswordModal from "./ChangePasswordModal";
+
+const setup = (overrides = {}) => {
+  const apiClient =
+    overrides.apiClient ||
+    {
+      verifyCurrentPassword: jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, data: {} }),
+      updatePassword: jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, data: {} }),
+    };
+
+  const onPasswordUpdated = overrides.onPasswordUpdated || jest.fn();
+  const onSessionExpired = overrides.onSessionExpired || jest.fn();
+  const onRequestClose = overrides.onRequestClose || jest.fn();
+
+  render(
+    <ChangePasswordModal
+      isOpen
+      onRequestClose={onRequestClose}
+      userId="user-123"
+      authToken="token-abc"
+      apiClient={apiClient}
+      onPasswordUpdated={onPasswordUpdated}
+      onSessionExpired={onSessionExpired}
+    />
+  );
+
+  return {
+    apiClient,
+    onPasswordUpdated,
+    onSessionExpired,
+    onRequestClose,
+  };
+};
+
+describe("ChangePasswordModal", () => {
+  it("runs full verify -> update success flow", async () => {
+    const onPasswordUpdated = jest.fn().mockResolvedValue(undefined);
+    const { apiClient } = setup({ onPasswordUpdated });
+
+    fireEvent.change(screen.getByLabelText("Current Password"), {
+      target: { value: "CurrentPass123!" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await screen.findByText("Step 2 of 2");
+
+    fireEvent.change(screen.getByLabelText("New Password"), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm New Password"), {
+      target: { value: "NewStrongPass123!" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Password" }));
+
+    await waitFor(() => {
+      expect(apiClient.updatePassword).toHaveBeenCalledTimes(1);
+      expect(onPasswordUpdated).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows inline field error when current password is invalid", async () => {
+    const { apiClient } = setup({
+      apiClient: {
+        verifyCurrentPassword: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 401,
+          data: { error: "Invalid password" },
+        }),
+        updatePassword: jest.fn(),
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText("Current Password"), {
+      target: { value: "WrongPassword" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() => {
+      expect(apiClient.verifyCurrentPassword).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Current password is incorrect.")).toBeTruthy();
+      expect(
+        screen.getByText("Re-enter your current password and try again.")
+      ).toBeTruthy();
+    });
+  });
+
+  it("handles rate-limited update error state", async () => {
+    setup({
+      apiClient: {
+        verifyCurrentPassword: jest
+          .fn()
+          .mockResolvedValue({ ok: true, status: 200, data: {} }),
+        updatePassword: jest.fn().mockResolvedValue({
+          ok: false,
+          status: 429,
+          data: {},
+        }),
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText("Current Password"), {
+      target: { value: "CurrentPass123!" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await screen.findByText("Step 2 of 2");
+
+    fireEvent.change(screen.getByLabelText("New Password"), {
+      target: { value: "NewStrongPass123!" },
+    });
+    fireEvent.change(screen.getByLabelText("Confirm New Password"), {
+      target: { value: "NewStrongPass123!" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Password" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Too many attempts. Please wait before trying again.")
+      ).toBeTruthy();
+      expect(screen.getByText("Try again in about 60 seconds.")).toBeTruthy();
+    });
+  });
+});

--- a/src/routes/UI-Only-Pages/UserProfilePage/changePasswordApi.js
+++ b/src/routes/UI-Only-Pages/UserProfilePage/changePasswordApi.js
@@ -1,0 +1,98 @@
+const API_BASE = "http://localhost:80";
+const VERIFY_ENDPOINT = `${API_BASE}/api/userpassword/verify`;
+const UPDATE_ENDPOINT = `${API_BASE}/api/userpassword/update`;
+const LEGACY_ENDPOINT = `${API_BASE}/api/userpassword`;
+
+const parseJsonSafe = async (response) => {
+  try {
+    return await response.json();
+  } catch (_error) {
+    return {};
+  }
+};
+
+const requestJson = async (url, options) => {
+  const response = await fetch(url, options);
+  const data = await parseJsonSafe(response);
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    data,
+  };
+};
+
+const buildHeaders = (token) => {
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+};
+
+// Temporary compatibility layer: until dedicated verify/update endpoints are finalized,
+// fallback to legacy PUT /api/userpassword endpoint.
+export const verifyCurrentPassword = async ({ userId, currentPassword, token }) => {
+  const payload = {
+    user_id: userId,
+    password: currentPassword,
+  };
+
+  const primary = await requestJson(VERIFY_ENDPOINT, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+  if (primary.status !== 404 && primary.status !== 405) {
+    return primary;
+  }
+
+  return requestJson(LEGACY_ENDPOINT, {
+    method: "PUT",
+    headers: buildHeaders(token),
+    body: JSON.stringify({
+      user_id: userId,
+      password: currentPassword,
+      new_password: currentPassword,
+    }),
+  });
+};
+
+export const updatePassword = async ({
+  userId,
+  currentPassword,
+  newPassword,
+  token,
+}) => {
+  const payload = {
+    user_id: userId,
+    password: currentPassword,
+    new_password: newPassword,
+  };
+
+  const primary = await requestJson(UPDATE_ENDPOINT, {
+    method: "PUT",
+    headers: buildHeaders(token),
+    body: JSON.stringify(payload),
+  });
+
+  if (primary.status !== 404 && primary.status !== 405) {
+    return primary;
+  }
+
+  return requestJson(LEGACY_ENDPOINT, {
+    method: "PUT",
+    headers: buildHeaders(token),
+    body: JSON.stringify(payload),
+  });
+};
+
+export const changePasswordApi = {
+  verifyCurrentPassword,
+  updatePassword,
+};

--- a/src/routes/UI-Only-Pages/UserProfilePage/changePasswordValidation.js
+++ b/src/routes/UI-Only-Pages/UserProfilePage/changePasswordValidation.js
@@ -1,0 +1,179 @@
+export const PASSWORD_RULES = [
+  {
+    key: "minLength",
+    label: "At least 8 characters",
+    test: (password) => password.length >= 8,
+  },
+  {
+    key: "uppercase",
+    label: "At least 1 uppercase letter",
+    test: (password) => /[A-Z]/.test(password),
+  },
+  {
+    key: "lowercase",
+    label: "At least 1 lowercase letter",
+    test: (password) => /[a-z]/.test(password),
+  },
+  {
+    key: "number",
+    label: "At least 1 number",
+    test: (password) => /[0-9]/.test(password),
+  },
+  {
+    key: "special",
+    label: "At least 1 special character",
+    test: (password) => /[!@#$%^&*()_\-+=[\]{};':"\\|,.<>/?]/.test(password),
+  },
+];
+
+export const getPasswordChecklist = (password = "") => {
+  const value = String(password || "");
+  return PASSWORD_RULES.reduce((acc, rule) => {
+    acc[rule.key] = rule.test(value);
+    return acc;
+  }, {});
+};
+
+export const isPasswordStrong = (checklist = {}) =>
+  PASSWORD_RULES.every((rule) => Boolean(checklist[rule.key]));
+
+export const validateVerifyStep = (currentPassword = "") => {
+  const errors = {};
+
+  if (!String(currentPassword || "").trim()) {
+    errors.currentPassword = "Current password is required.";
+  }
+
+  return errors;
+};
+
+export const validateUpdateStep = ({
+  currentPassword = "",
+  newPassword = "",
+  confirmPassword = "",
+}) => {
+  const errors = {};
+
+  if (!String(currentPassword || "").trim()) {
+    errors.currentPassword = "Current password is required.";
+  }
+
+  const checklist = getPasswordChecklist(newPassword);
+  if (!isPasswordStrong(checklist)) {
+    errors.newPassword = "Please choose a stronger password that meets all requirements.";
+  }
+
+  if (String(newPassword || "").trim() === "") {
+    errors.newPassword = "New password is required.";
+  }
+
+  if (String(confirmPassword || "").trim() === "") {
+    errors.confirmPassword = "Please confirm your new password.";
+  } else if (newPassword !== confirmPassword) {
+    errors.confirmPassword = "New password and confirmation do not match.";
+  }
+
+  if (currentPassword && newPassword && currentPassword === newPassword) {
+    errors.newPassword = "New password must be different from your current password.";
+  }
+
+  return errors;
+};
+
+const toLower = (value = "") => String(value || "").toLowerCase();
+
+export const mapPasswordApiError = ({ status = 0, data = {}, step = "verify" }) => {
+  const errorCode = String(
+    data?.code || data?.errorCode || data?.error_code || ""
+  ).toUpperCase();
+  const message = String(data?.error || data?.message || "").trim();
+  const messageLower = toLower(message);
+
+  const response = {
+    flowStatus: "api_error",
+    fieldErrors: {},
+    formError: message || "We could not process your request right now.",
+    retryGuidance: "Please check your input and try again.",
+    shouldRedirectToLogin: false,
+  };
+
+  if (status === 429 || errorCode.includes("RATE_LIMIT")) {
+    response.flowStatus = "rate_limited";
+    response.formError = "Too many attempts. Please wait before trying again.";
+    response.retryGuidance = "Try again in about 60 seconds.";
+    return response;
+  }
+
+  if (
+    (status === 401 || status === 403) &&
+    (
+      errorCode.includes("TOKEN") ||
+      errorCode.includes("UNAUTHORIZED") ||
+      messageLower.includes("token") ||
+      messageLower.includes("session") ||
+      messageLower.includes("unauthorized") ||
+      messageLower.includes("invalid user id")
+    )
+  ) {
+    response.formError = "Your session has expired. Please sign in again.";
+    response.retryGuidance = "You will be redirected to login for account recovery.";
+    response.shouldRedirectToLogin = true;
+    return response;
+  }
+
+  const isCurrentPasswordInvalid =
+    errorCode === "CURRENT_PASSWORD_INVALID" ||
+    errorCode === "INVALID_PASSWORD" ||
+    messageLower.includes("invalid password") ||
+    messageLower.includes("current password");
+
+  if (isCurrentPasswordInvalid) {
+    response.fieldErrors.currentPassword = "Current password is incorrect.";
+    response.formError = "";
+    response.retryGuidance = "Re-enter your current password and try again.";
+    return response;
+  }
+
+  if (
+    errorCode.includes("WEAK_PASSWORD") ||
+    messageLower.includes("weak password") ||
+    messageLower.includes("password strength")
+  ) {
+    response.fieldErrors.newPassword =
+      "Your new password is too weak. Please meet all password requirements.";
+    response.formError = "";
+    response.retryGuidance = "Use a stronger password and submit again.";
+    return response;
+  }
+
+  if (
+    errorCode.includes("PASSWORD_MISMATCH") ||
+    messageLower.includes("confirm") ||
+    messageLower.includes("mismatch")
+  ) {
+    response.fieldErrors.confirmPassword =
+      "New password and confirmation do not match.";
+    response.formError = "";
+    response.retryGuidance = "Update confirmation password and retry.";
+    return response;
+  }
+
+  if (status >= 500) {
+    response.formError = "Server error while processing password change.";
+    response.retryGuidance = "Please try again shortly.";
+    return response;
+  }
+
+  if (status === 400 && step === "verify") {
+    response.fieldErrors.currentPassword = "Current password is required.";
+    response.formError = "";
+    response.retryGuidance = "Enter your current password to continue.";
+  }
+
+  if (status === 400 && step === "update" && !response.fieldErrors.newPassword) {
+    response.fieldErrors.newPassword = "Please review your new password and try again.";
+    response.formError = "";
+  }
+
+  return response;
+};

--- a/src/routes/UI-Only-Pages/UserProfilePage/changePasswordValidation.test.js
+++ b/src/routes/UI-Only-Pages/UserProfilePage/changePasswordValidation.test.js
@@ -1,0 +1,51 @@
+import {
+  getPasswordChecklist,
+  isPasswordStrong,
+  mapPasswordApiError,
+  validateUpdateStep,
+  validateVerifyStep,
+} from "./changePasswordValidation";
+
+describe("changePasswordValidation", () => {
+  it("validates verify step current password requirement", () => {
+    expect(validateVerifyStep("")).toEqual({
+      currentPassword: "Current password is required.",
+    });
+
+    expect(validateVerifyStep("CurrentPass123!")).toEqual({});
+  });
+
+  it("returns checklist values and strong-password decision", () => {
+    const weakChecklist = getPasswordChecklist("abc");
+    expect(isPasswordStrong(weakChecklist)).toBe(false);
+
+    const strongChecklist = getPasswordChecklist("StrongPass123!");
+    expect(isPasswordStrong(strongChecklist)).toBe(true);
+  });
+
+  it("validates update step field-level rules", () => {
+    const errors = validateUpdateStep({
+      currentPassword: "CurrentPass123!",
+      newPassword: "weak",
+      confirmPassword: "weaker",
+    });
+
+    expect(errors.newPassword).toBeTruthy();
+    expect(errors.confirmPassword).toBe("New password and confirmation do not match.");
+  });
+
+  it("maps rate-limited and invalid-password API responses", () => {
+    const rateLimited = mapPasswordApiError({ status: 429, data: {}, step: "verify" });
+    expect(rateLimited.flowStatus).toBe("rate_limited");
+
+    const invalidPassword = mapPasswordApiError({
+      status: 401,
+      data: { error: "Invalid password" },
+      step: "verify",
+    });
+
+    expect(invalidPassword.fieldErrors.currentPassword).toBe(
+      "Current password is incorrect."
+    );
+  });
+});

--- a/src/routes/UI-Only-Pages/UserProfilePage/userprofile.jsx
+++ b/src/routes/UI-Only-Pages/UserProfilePage/userprofile.jsx
@@ -1,6 +1,7 @@
   "use client"
 
   import { useContext, useMemo, useRef, useState, useEffect } from "react"
+  import { ArrowRight, KeyRound, ShieldCheck, TimerReset } from "lucide-react"
   import { useNavigate } from "react-router-dom"
   import { toast } from "react-toastify"
   import profileLogo from "./NutriHelp-logos_black.png"
@@ -211,6 +212,138 @@
   const getButtonHoverStyles = (width) => ({
     ...getButtonStyles(width),
     background: "#1e54d9",
+  })
+
+  const getPasswordPanelStyles = (width) => ({
+    position: "relative",
+    overflow: "hidden",
+    borderRadius: width < 768 ? 18 : 24,
+    padding: width < 768 ? "22px 18px" : width < 1024 ? "30px 24px" : "34px 30px",
+    border: "1px solid rgba(30, 64, 175, 0.28)",
+    background:
+      "linear-gradient(136deg, #0f172a 0%, #1d4ed8 52%, #0f766e 128%)",
+    boxShadow: "0 20px 46px rgba(15, 23, 42, 0.28)",
+    display: "grid",
+    gridTemplateColumns:
+      width < 980 ? "1fr" : "minmax(0, 1.3fr) minmax(260px, 0.7fr)",
+    gap: width < 980 ? 20 : 24,
+    color: "#f8fafc",
+  })
+
+  const getPasswordOrbStyles = (position) => ({
+    position: "absolute",
+    width: position === "top" ? 220 : 260,
+    height: position === "top" ? 220 : 260,
+    borderRadius: "50%",
+    pointerEvents: "none",
+    zIndex: 0,
+    top: position === "top" ? -90 : "auto",
+    right: position === "top" ? -70 : "auto",
+    left: position === "bottom" ? -100 : "auto",
+    bottom: position === "bottom" ? -120 : "auto",
+    background:
+      position === "top"
+        ? "radial-gradient(circle, rgba(165, 180, 252, 0.32), rgba(165, 180, 252, 0))"
+        : "radial-gradient(circle, rgba(45, 212, 191, 0.24), rgba(45, 212, 191, 0))",
+  })
+
+  const getPasswordContentStyles = () => ({
+    position: "relative",
+    zIndex: 1,
+  })
+
+  const getPasswordBadgeStyles = () => ({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 8,
+    borderRadius: 999,
+    border: "1px solid rgba(191, 219, 254, 0.35)",
+    background: "rgba(15, 23, 42, 0.2)",
+    color: "rgba(219, 234, 254, 0.98)",
+    fontSize: 12,
+    fontWeight: 700,
+    padding: "6px 12px",
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+    marginBottom: 14,
+  })
+
+  const getPasswordHeadingStyles = (width) => ({
+    margin: 0,
+    fontSize: width < 768 ? 34 : width < 1024 ? 40 : 46,
+    lineHeight: 1.08,
+    letterSpacing: "-0.02em",
+    fontWeight: 800,
+    color: "#f8fafc",
+    fontFamily: "\"Sora\", \"Poppins\", sans-serif",
+  })
+
+  const getPasswordDescriptionStyles = (width) => ({
+    margin: "16px 0 0",
+    maxWidth: 720,
+    color: "rgba(226, 232, 240, 0.95)",
+    fontSize: width < 768 ? 15 : 18,
+    lineHeight: 1.55,
+    fontWeight: 500,
+    fontFamily: "\"Manrope\", \"Poppins\", sans-serif",
+  })
+
+  const getPasswordActionStyles = (width, hovered, disabled) => ({
+    marginTop: width < 768 ? 20 : 24,
+    minHeight: width < 768 ? 50 : 56,
+    padding: width < 768 ? "0 20px" : "0 26px",
+    borderRadius: 14,
+    border: "1px solid rgba(255,255,255,0.3)",
+    background: disabled
+      ? "linear-gradient(135deg, #cbd5e1 0%, #94a3b8 100%)"
+      : hovered
+      ? "linear-gradient(135deg, #ffffff 0%, #dbeafe 100%)"
+      : "linear-gradient(135deg, #ffffff 0%, #f1f5f9 100%)",
+    color: disabled ? "#475569" : "#0f172a",
+    fontSize: width < 768 ? 16 : 17,
+    fontWeight: 800,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 10,
+    width: width < 768 ? "100%" : "auto",
+    cursor: disabled ? "not-allowed" : "pointer",
+    boxShadow: disabled
+      ? "none"
+      : hovered
+      ? "0 14px 28px rgba(30, 64, 175, 0.36)"
+      : "0 12px 22px rgba(15, 23, 42, 0.24)",
+    transform: hovered && !disabled ? "translateY(-2px)" : "translateY(0)",
+    transition: "all 0.2s ease",
+  })
+
+  const getPasswordMetaStyles = (width) => ({
+    position: "relative",
+    zIndex: 1,
+    display: "grid",
+    gap: 12,
+    marginTop: width < 980 ? 0 : 18,
+  })
+
+  const getPasswordMetaItemStyles = () => ({
+    display: "flex",
+    alignItems: "center",
+    gap: 10,
+    borderRadius: 12,
+    padding: "11px 12px",
+    border: "1px solid rgba(191, 219, 254, 0.28)",
+    background: "rgba(15, 23, 42, 0.24)",
+    color: "rgba(239, 246, 255, 0.98)",
+    fontSize: 13,
+    fontWeight: 600,
+    fontFamily: "\"Manrope\", \"Poppins\", sans-serif",
+  })
+
+  const getPasswordWarningStyles = () => ({
+    marginTop: 10,
+    color: "#fef08a",
+    fontSize: 13,
+    fontWeight: 600,
   })
 
   /* ============ CUSTOM RADIO STYLES ============ */
@@ -499,29 +632,60 @@ const getRadioInnerStyles = (checked) => ({
             </section>
 
             {/* Your Password Section */}
-            <section style={getCardStyles(width)}>
-              <h2 style={getTitleStyles(width)}>Your Password</h2>
+            <section style={getPasswordPanelStyles(width)}>
+              <div style={getPasswordOrbStyles("top")} />
+              <div style={getPasswordOrbStyles("bottom")} />
 
-              <p style={{ marginTop: -8, color: "#475569", lineHeight: 1.5, marginBottom: 16 }}>
-                For account security, password updates require verifying your current password first.
-                Click the button below to open the secure 2-step password change flow.
-              </p>
-
-              <button
-                style={hoveredButton === "changePassword" ? getButtonHoverStyles(width) : getButtonStyles(width)}
-                onMouseEnter={() => setHoveredButton("changePassword")}
-                onMouseLeave={() => setHoveredButton(null)}
-                onClick={() => setIsChangePasswordOpen(true)}
-                disabled={!currentUserId}
-              >
-                Change Password
-              </button>
-
-              {!currentUserId ? (
-                <div style={{ marginTop: 10, color: "#b45309", fontSize: 13 }}>
-                  Unable to load your account session. Please sign in again.
+              <div style={getPasswordContentStyles()}>
+                <div style={getPasswordBadgeStyles()}>
+                  <ShieldCheck size={14} />
+                  Account Security
                 </div>
-              ) : null}
+
+                <h2 style={getPasswordHeadingStyles(width)}>Your Password</h2>
+
+                <p style={getPasswordDescriptionStyles(width)}>
+                  Guard your account with a secure 2-step password update flow.
+                  First verify your current password, then set a stronger new one
+                  with real-time validation.
+                </p>
+
+                <button
+                  style={getPasswordActionStyles(
+                    width,
+                    hoveredButton === "changePassword",
+                    !currentUserId
+                  )}
+                  onMouseEnter={() => setHoveredButton("changePassword")}
+                  onMouseLeave={() => setHoveredButton(null)}
+                  onClick={() => setIsChangePasswordOpen(true)}
+                  disabled={!currentUserId}
+                >
+                  Change Password
+                  <ArrowRight size={18} />
+                </button>
+
+                {!currentUserId ? (
+                  <div style={getPasswordWarningStyles()}>
+                    Unable to load your account session. Please sign in again.
+                  </div>
+                ) : null}
+              </div>
+
+              <div style={getPasswordMetaStyles(width)}>
+                <div style={getPasswordMetaItemStyles()}>
+                  <KeyRound size={16} />
+                  Current password verification gate
+                </div>
+                <div style={getPasswordMetaItemStyles()}>
+                  <ShieldCheck size={16} />
+                  Inline strength and mismatch checks
+                </div>
+                <div style={getPasswordMetaItemStyles()}>
+                  <TimerReset size={16} />
+                  Session protection after update
+                </div>
+              </div>
             </section>
           </main>
 

--- a/src/routes/UI-Only-Pages/UserProfilePage/userprofile.jsx
+++ b/src/routes/UI-Only-Pages/UserProfilePage/userprofile.jsx
@@ -1,7 +1,12 @@
   "use client"
 
-  import { useMemo, useRef, useState, useEffect } from "react"
+  import { useContext, useMemo, useRef, useState, useEffect } from "react"
+  import { useNavigate } from "react-router-dom"
+  import { toast } from "react-toastify"
   import profileLogo from "./NutriHelp-logos_black.png"
+  import { UserContext } from "../../../context/user.context"
+  import { supabase } from "../../../supabaseClient"
+  import ChangePasswordModal from "./ChangePasswordModal"
 
 
   /* ============ CONSTANTS ============ */
@@ -19,8 +24,6 @@
     lastName: "",
     email: "",
     phone: "",
-    password: "",
-    confirm: "",
     goals: [],
     avatar: null,
   }
@@ -247,20 +250,50 @@ const getRadioInnerStyles = (checked) => ({
     const [form, setForm] = useState(INITIAL_FORM)
     const [touched, setTouched] = useState({})
     const [hoveredButton, setHoveredButton] = useState(null)
+    const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false)
     const fileRef = useRef(null)
+    const navigate = useNavigate()
+    const { currentUser, logOut, setCurrentUser } = useContext(UserContext)
+
+    const storedSession = useMemo(() => {
+      try {
+        const raw = localStorage.getItem("user_session")
+        return raw ? JSON.parse(raw) : null
+      } catch (_error) {
+        return null
+      }
+    }, [currentUser, isChangePasswordOpen])
+
+    const currentUserId =
+      currentUser?.id ||
+      currentUser?.user_id ||
+      storedSession?.id ||
+      storedSession?.user_id ||
+      ""
+
+    const authToken =
+      localStorage.getItem("auth_token") ||
+      localStorage.getItem("jwt_token") ||
+      currentUser?.token ||
+      storedSession?.token ||
+      ""
 
   useEffect(() => {
   const fetchProfile = async () => {
     try {
       const sessionRaw = localStorage.getItem("user_session")
-      const token = localStorage.getItem("jwt_token")
+      const parsedSession = sessionRaw ? JSON.parse(sessionRaw) : null
+      const token =
+        localStorage.getItem("auth_token") ||
+        localStorage.getItem("jwt_token") ||
+        parsedSession?.token
 
-      if (!sessionRaw || !token) {
+      if (!parsedSession || !token) {
         console.warn("JWT token missing")
         return
       }
 
-      const session = JSON.parse(sessionRaw)
+      const session = parsedSession
 
       const res = await fetch("http://localhost:80/api/profile", {
         method: "GET",
@@ -311,8 +344,6 @@ const getRadioInnerStyles = (checked) => ({
       if (touched.firstName && !form.firstName) e.firstName = "Required"
       if (touched.email && !emailOk(form.email)) e.email = "Invalid email"
       if (touched.phone && !phoneOk(form.phone)) e.phone = "Invalid phone"
-      if (touched.password && form.password.length < 6) e.password = "Min 6 chars"
-      if (touched.confirm && form.confirm !== form.password) e.confirm = "Mismatch"
       return e
     }, [form, touched])
 
@@ -327,16 +358,38 @@ const getRadioInnerStyles = (checked) => ({
       mark("email")
       mark("phone")
       if (Object.keys(errors).length === 0) {
-        alert("Changes saved!")
+        toast.success("Profile changes saved.")
       }
     }
 
-    const handleUpdatePassword = () => {
-      mark("password")
-      mark("confirm")
-      if (Object.keys(errors).length === 0) {
-        alert("Password updated!")
+    const completeLogoutAndRedirect = async () => {
+      try {
+        await supabase.auth.signOut()
+      } catch (_error) {
+        // Ignore Supabase sign-out errors and continue local/session cleanup.
       }
+
+      localStorage.removeItem("auth_token")
+      localStorage.removeItem("jwt_token")
+      localStorage.removeItem("user_session")
+
+      if (typeof logOut === "function") {
+        logOut()
+      } else if (typeof setCurrentUser === "function") {
+        setCurrentUser(null)
+      }
+
+      navigate("/login", { replace: true })
+    }
+
+    const handlePasswordUpdated = async () => {
+      toast.success("Password changed successfully. Please sign in again.")
+      await completeLogoutAndRedirect()
+    }
+
+    const handlePasswordSessionExpired = async (message) => {
+      toast.info(message || "Session expired. Please sign in again.")
+      await completeLogoutAndRedirect()
     }
 
     return (
@@ -449,37 +502,37 @@ const getRadioInnerStyles = (checked) => ({
             <section style={getCardStyles(width)}>
               <h2 style={getTitleStyles(width)}>Your Password</h2>
 
-              <div style={getGrid2Styles(width)}>
-                <FormField
-                  label="New Password"
-                  type="password"
-                  value={form.password}
-                  onChange={(v) => set("password", v)}
-                  onBlur={() => mark("password")}
-                  error={touched.password ? errors.password : undefined}
-                  width={width}
-                />
-                <FormField
-                  label="Repeat New Password"
-                  type="password"
-                  value={form.confirm}
-                  onChange={(v) => set("confirm", v)}
-                  onBlur={() => mark("confirm")}
-                  error={touched.confirm ? errors.confirm : undefined}
-                  width={width}
-                />
-              </div>
+              <p style={{ marginTop: -8, color: "#475569", lineHeight: 1.5, marginBottom: 16 }}>
+                For account security, password updates require verifying your current password first.
+                Click the button below to open the secure 2-step password change flow.
+              </p>
 
               <button
-                style={hoveredButton === "password" ? getButtonHoverStyles(width) : getButtonStyles(width)}
-                onMouseEnter={() => setHoveredButton("password")}
+                style={hoveredButton === "changePassword" ? getButtonHoverStyles(width) : getButtonStyles(width)}
+                onMouseEnter={() => setHoveredButton("changePassword")}
                 onMouseLeave={() => setHoveredButton(null)}
-                onClick={handleUpdatePassword}
+                onClick={() => setIsChangePasswordOpen(true)}
+                disabled={!currentUserId}
               >
-                Update Password
+                Change Password
               </button>
+
+              {!currentUserId ? (
+                <div style={{ marginTop: 10, color: "#b45309", fontSize: 13 }}>
+                  Unable to load your account session. Please sign in again.
+                </div>
+              ) : null}
             </section>
           </main>
+
+          <ChangePasswordModal
+            isOpen={isChangePasswordOpen}
+            onRequestClose={() => setIsChangePasswordOpen(false)}
+            userId={currentUserId}
+            authToken={authToken}
+            onPasswordUpdated={handlePasswordUpdated}
+            onSessionExpired={handlePasswordSessionExpired}
+          />
         </div>
       </div>
     )


### PR DESCRIPTION
## Ticket
**FE04 - [Profile-PasswordChange] Secure Change Password Flow with Step-Up Verification**

---

## Description
Implemented a production-grade 2-step **Change Password** flow in **Account Profile** to replace the previously exposed inline password form.

### What was completed
- Replaced the inline password inputs with a single **Change Password** call-to-action.
- Added a dedicated modal-based flow:
  - **Step 1:** Verify Current Password
  - **Step 2:** Set New Password + Confirm
- Added a real-time password strength checklist with strict client-side validation.
- Added API error mapping to provide clear, user-friendly, field-level error messages.
- Added loading, disabled, and rate-limit handling states.
- Added session-expired / unauthorized handling with controlled logout and redirect to **Login**.
- Applied the security policy so that, after a successful password change, the user is signed out and redirected to **Login**.
- Added accessibility improvements, including:
  - dialog semantics
  - keyboard trap
  - ESC close when safe
  - show / hide password controls
- Replaced the profile success alert with the app-standard toast feedback.

---

## Files changed and purpose

### `userprofile.jsx`
- Removed the exposed inline password form.
- Added the **Change Password** CTA.
- Mounted the password change modal.
- Integrated secure logout and redirect behavior.
- Replaced profile save feedback from `alert` to `toast`.

### `ChangePasswordModal.jsx`
- New dedicated component implementing the 2-step state-machine flow.
- Handles form state, validation, error handling, API calls, accessibility behavior, and success transition.

### `ChangePasswordModal.css`
- New responsive styling for:
  - modal and panel states
  - buttons
  - error blocks
  - password checklist
  - mobile layout

### `changePasswordApi.js`
- New API layer for password verification and update.
- Includes normalized response handling and backward-compatible fallback to the legacy endpoint.

### `changePasswordValidation.js`
- New validation utility and password checklist logic.
- Includes backend error-code / message mapping for field-level and global errors.

### `changePasswordValidation.test.js`
- Added unit tests for:
  - password rules
  - validation behavior
  - error mapping

### `ChangePasswordModal.test.jsx`
- Added integration tests for:
  - full modal flow
  - weak-password blocking
  - rate-limit errors
  - session-expired handling

### `package.json`
- Added frontend test dependencies required for modal integration tests.

### `package-lock.json`
- Lockfile updated after dependency installation.

---

## API note / exclusion
Frontend currently uses:
- `POST /api/userpassword/verify`
- `PUT /api/userpassword/update`

Also added a fallback to:
- `PUT /api/userpassword`

This was included for legacy compatibility until the FE + BE contract is fully finalized.

---

## How to test

### Functional checks
1. Open `/userProfile`.
2. Verify that only the **Change Password** CTA is shown in the **Your Password** section.
3. Confirm there are no inline password fields displayed.
4. Click **Change Password**.
5. In **Step 1**, enter the current password and click **Verify**.
6. In **Step 2**, enter the new password and confirm it.
7. Verify the real-time password checklist updates as expected.
8. Verify submit remains disabled when the form is invalid.
9. Verify inline validation errors appear for invalid inputs.
10. On success, verify the user is forcibly logged out and redirected to `/login`.
11. Verify unauthorized or session-expired responses trigger login recovery via redirect.

### Screenshots
<img width="1728" height="998" alt="Screenshot 2026-03-27 at 03 08 05" src="https://github.com/user-attachments/assets/5e389b6d-096a-48ff-a9a4-3ca83aeee071" />
<img width="715" height="513" alt="Screenshot 2026-03-27 at 03 08 30" src="https://github.com/user-attachments/assets/4d76f8f1-f8e3-406d-bea2-a49b751bb119" />
<img width="659" height="681" alt="Screenshot 2026-03-27 at 03 08 52" src="https://github.com/user-attachments/assets/504f5e75-e829-4be8-9cb0-bea6cc91a68d" />

### Run tests
```bash
npm test -- --runInBand --runTestsByPath src/routes/UI-Only-Pages/UserProfilePage/changePasswordValidation.test.js src/routes/UI-Only-Pages/UserProfilePage/ChangePasswordModal.test.jsx.```          


