### PR TITLE
feat: integrate AI personalised meal plan into /Meal page

### DIFF
--- a/src/routes/Meal/Meal.css
+++ b/src/routes/Meal/Meal.css
@@ -1475,3 +1475,51 @@
     min-height: 42px;
   }
 }
+
+/* ── Page-level tab switcher ─────────────────────────────────────────────── */
+.meal-tab-switcher {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  border-bottom: 2px solid var(--line);
+  padding-bottom: 0;
+}
+
+.meal-tab-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 20px;
+  border: none;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+  color: var(--ink-soft);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-bottom: -2px;
+  transition: color 0.18s ease, border-color 0.18s ease;
+  white-space: nowrap;
+}
+
+.meal-tab-btn:hover {
+  color: var(--ink-strong);
+}
+
+.meal-tab-btn.active {
+  color: var(--brand);
+  border-bottom-color: var(--brand);
+}
+
+/* ── Personalized plan section ───────────────────────────────────────────── */
+.personalized-plan-section {
+  padding-top: 8px;
+}
+
+@media (max-width: 640px) {
+  .meal-tab-btn {
+    padding: 8px 14px;
+    font-size: 0.875rem;
+  }
+}

--- a/src/routes/Meal/Meal.jsx
+++ b/src/routes/Meal/Meal.jsx
@@ -12,9 +12,14 @@ import {
   Search,
   Settings2,
   ShoppingCart,
+  Sparkles,
   Trash2,
   Users,
 } from "lucide-react";
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+import PersonalizedPlanForm from "./PersonalizedPlanForm";
+import PersonalizedWeeklyPlan from "./PersonalizedWeeklyPlan";
 
 const FILTERS = [
   { key: "breakfast", label: "Breakfast" },
@@ -621,6 +626,9 @@ const Meal = () => {
     normalizeSelectionsByDate(readSelectionsByDateFromStorage()),
   );
 
+  const [activeTab, setActiveTab] = useState('addMeal');
+  const [planFilters, setPlanFilters] = useState(null);
+
   const normalizedQuery = normalize(query);
 
   const selectedMealMap = useMemo(
@@ -1182,6 +1190,23 @@ const Meal = () => {
     });
   };
 
+  const handleGeneratePlan = (filters) => {
+    setPlanFilters(filters);
+  };
+
+  const handleExportPDF = () => {
+    const printArea = document.getElementById('personalized-meal-plan');
+    if (!printArea) return;
+    html2canvas(printArea, { scale: 2 }).then((canvas) => {
+      const imgData = canvas.toDataURL('image/png');
+      const pdf = new jsPDF('p', 'mm', 'a4');
+      const imgWidth = 210;
+      const imgHeight = (canvas.height * imgWidth) / canvas.width;
+      pdf.addImage(imgData, 'PNG', 0, 0, imgWidth, imgHeight);
+      pdf.save('Personalized_Meal_Plan.pdf');
+    });
+  };
+
   const selectedCount = selectedMeals.length;
   const selectedViewCount = SELECTED_VIEW_SECTIONS.reduce(
     (total, section) => total + selectedMealGroups[section.key].length,
@@ -1209,6 +1234,25 @@ const Meal = () => {
           <span className="crumb-current">Add Meal</span>
         </div>
 
+        <div className="meal-tab-switcher">
+          <button
+            type="button"
+            className={`meal-tab-btn ${activeTab === 'addMeal' ? 'active' : ''}`}
+            onClick={() => setActiveTab('addMeal')}
+          >
+            Add Meal
+          </button>
+          <button
+            type="button"
+            className={`meal-tab-btn ${activeTab === 'personalizedPlan' ? 'active' : ''}`}
+            onClick={() => setActiveTab('personalizedPlan')}
+          >
+            <Sparkles size={15} />
+            AI Personalized Plan
+          </button>
+        </div>
+
+        {activeTab === 'addMeal' && (<>
         <div className="add-meal-toolbar">
           <div className="add-meal-date-row" aria-label="Plan date controls">
             <button
@@ -1832,6 +1876,24 @@ const Meal = () => {
             </div>
           </aside>
         </div>
+        </>)}
+
+        {activeTab === 'personalizedPlan' && (
+          <div className="personalized-plan-section">
+            <PersonalizedPlanForm
+              onGenerate={handleGeneratePlan}
+              onExport={planFilters ? handleExportPDF : undefined}
+              loading={false}
+            />
+            {planFilters && (
+              <PersonalizedWeeklyPlan
+                filters={planFilters}
+                onExport={handleExportPDF}
+                showExport={true}
+              />
+            )}
+          </div>
+        )}
       </div>
 
       <div

--- a/src/routes/Meal/PersonalizedPlan.css
+++ b/src/routes/Meal/PersonalizedPlan.css
@@ -1,0 +1,295 @@
+/* PersonalizedPlan.css — styles for PersonalizedPlanForm + PersonalizedWeeklyPlan */
+
+/* ── CSS variable bridge (maps to Meal.css tokens) ─────────────────────── */
+.personalize-card,
+.personalized-plan-section {
+  --pp-brand:        #005bbb;
+  --pp-brand-hover:  #00489a;
+  --pp-brand-soft:   #eaf2ff;
+  --pp-ink-strong:   #0f172a;
+  --pp-ink-body:     #334155;
+  --pp-ink-soft:     #64748b;
+  --pp-line:         #d8e0ec;
+  --pp-bg:           #ffffff;
+  --pp-bg-soft:      #f8fafc;
+  --pp-success-bg:   #dcfce7;
+  --pp-success-ink:  #166534;
+  --pp-danger-bg:    #fee2e2;
+  --pp-danger-ink:   #991b1b;
+  --pp-radius-card:  14px;
+  --pp-radius-input: 10px;
+  --pp-shadow:       0 2px 12px rgba(10, 30, 70, 0.07);
+
+  /* bridge to PersonalizedWeeklyPlan inline styles */
+  --primary-color:          #005bbb;
+  --primary-hover:          #00489a;
+  --primary-light:          #eaf2ff;
+  --text-primary:           #0f172a;
+  --text-secondary:         #64748b;
+  --text-muted:             #94a3b8;
+  --text-inverse:           #ffffff;
+  --border-color:           #d8e0ec;
+  --background-secondary:   #f8fafc;
+  --card-background:        #ffffff;
+  --card-background-secondary: #f8fafc;
+  --input-background:       #ffffff;
+  --error-color:            #dc2626;
+}
+
+/* ── Form card ──────────────────────────────────────────────────────────── */
+.personalize-card {
+  background: var(--pp-bg);
+  border: 1px solid var(--pp-line);
+  border-radius: var(--pp-radius-card);
+  padding: 28px 28px 24px;
+  box-shadow: var(--pp-shadow);
+  margin-bottom: 28px;
+}
+
+.personalize-title {
+  margin: 0 0 24px;
+  font-size: 1.375rem;
+  font-weight: 800;
+  color: var(--pp-ink-strong);
+  letter-spacing: -0.01em;
+}
+
+/* ── 2-col grid for Basic Preferences ──────────────────────────────────── */
+.personalize-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 20px;
+}
+
+@media (max-width: 640px) {
+  .personalize-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Field wrapper ──────────────────────────────────────────────────────── */
+.personalize-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.personalize-label {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--pp-ink-body);
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+/* ── Inputs / selects / textareas ───────────────────────────────────────── */
+.personalize-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 14px;
+  border: 1.5px solid var(--pp-line);
+  border-radius: var(--pp-radius-input);
+  background: var(--pp-bg);
+  color: var(--pp-ink-strong);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.personalize-input:focus {
+  outline: none;
+  border-color: var(--pp-brand);
+  box-shadow: 0 0 0 3px rgba(0, 91, 187, 0.12);
+}
+
+select.personalize-input {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2.5'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
+  cursor: pointer;
+}
+
+/* ── Chip rows ──────────────────────────────────────────────────────────── */
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 16px;
+  border: 1.5px solid var(--pp-line);
+  border-radius: 999px;
+  background: var(--pp-bg);
+  color: var(--pp-ink-body);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.16s ease;
+  white-space: nowrap;
+  min-height: 36px;
+}
+
+.chip:hover {
+  border-color: var(--pp-brand);
+  color: var(--pp-brand);
+  background: var(--pp-brand-soft);
+}
+
+.chip--active {
+  border-color: var(--pp-brand);
+  background: var(--pp-brand);
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.chip--active:hover {
+  background: var(--pp-brand-hover);
+  border-color: var(--pp-brand-hover);
+  color: #ffffff;
+}
+
+/* ── Primary button ─────────────────────────────────────────────────────── */
+.btn-primary-solid {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 13px 28px;
+  border: none;
+  border-radius: 10px;
+  background: var(--pp-brand);
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.18s ease, transform 0.12s ease, box-shadow 0.18s ease;
+  box-shadow: 0 2px 8px rgba(0, 91, 187, 0.25);
+}
+
+.btn-primary-solid:hover:not(:disabled) {
+  background: var(--pp-brand-hover);
+  box-shadow: 0 4px 14px rgba(0, 91, 187, 0.35);
+  transform: translateY(-1px);
+}
+
+.btn-primary-solid:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.btn-primary-solid:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* ── Export / secondary button ──────────────────────────────────────────── */
+.export-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 13px 24px;
+  border: 1.5px solid var(--pp-brand);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--pp-brand);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.12s ease;
+}
+
+.export-btn:hover {
+  background: var(--pp-brand-soft);
+  transform: translateY(-1px);
+}
+
+/* ── Actions row ────────────────────────────────────────────────────────── */
+.personalize-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+/* ── Generate bar ───────────────────────────────────────────────────────── */
+.personalize-generate-bar {
+  margin-top: 24px;
+  padding: 20px 24px;
+  border-radius: 12px;
+  background: var(--pp-brand-soft);
+  border: 1.5px solid #bfdbfe;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.personalize-generate-hint {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--pp-ink-body);
+  flex: 1 1 200px;
+}
+
+.personalize-generate-btn {
+  font-size: 1.0625rem;
+  padding: 14px 32px;
+  min-height: 50px;
+  flex-shrink: 0;
+}
+
+/* ── Spinner ────────────────────────────────────────────────────────────── */
+.pp-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  flex-shrink: 0;
+}
+
+/* ── Spin keyframe (used by button loading spinner) ─────────────────────── */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+@media (max-width: 640px) {
+  .personalize-card {
+    padding: 18px 16px 20px;
+  }
+
+  .personalize-generate-bar {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px;
+  }
+
+  .personalize-generate-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .personalize-actions {
+    flex-direction: column;
+  }
+
+  .export-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/src/routes/Meal/PersonalizedPlanForm.jsx
+++ b/src/routes/Meal/PersonalizedPlanForm.jsx
@@ -1,5 +1,6 @@
 // src/routes/Meal/PersonalizedPlanForm.jsx
 import { useState } from 'react';
+import './PersonalizedPlan.css';
 
 const DIET_TYPES = [
   { value: 'balanced', label: 'Balanced' },
@@ -386,44 +387,38 @@ export default function PersonalizedPlanForm({ onGenerate, onExport, loading = f
         </div>
       </CollapsibleSection>
 
-      <div className="personalize-actions" style={{ display: 'flex', gap: 12, marginTop: 20 }}>
-        <button
-          type="submit"
-          className="btn-primary-solid"
-          disabled={loading}
-          style={{ minHeight: 48, fontSize: '1.125rem' }}
-        >
-          {loading ? (
-            <>
-              <span
-                aria-hidden="true"
-                style={{
-                  display: 'inline-block',
-                  width: 16,
-                  height: 16,
-                  border: '2px solid #ffffff',
-                  borderTopColor: 'transparent',
-                  borderRadius: '50%',
-                  animation: 'spin 0.8s linear infinite',
-                  marginRight: 8,
-                  verticalAlign: 'middle',
-                }}
-              />
-              Generating plan...
-            </>
-          ) : 'Generate My 7-Day Plan'}
-        </button>
-
-        {onExport && (
+      <div className="personalize-generate-bar">
+        <div className="personalize-generate-hint">
+          Reviewed your preferences? Generate your personalised 7-day AI meal plan.
+        </div>
+        <div className="personalize-actions">
           <button
-            type="button"
-            className="export-btn"
-            onClick={onExport}
-            style={{ minHeight: 48 }}
+            type="submit"
+            className="btn-primary-solid personalize-generate-btn"
+            disabled={loading}
           >
-            Export as PDF
+            {loading ? (
+              <>
+                <span className="pp-spinner" aria-hidden="true" />
+                Generating plan…
+              </>
+            ) : (
+              <>
+                ✨ Generate My 7-Day Plan
+              </>
+            )}
           </button>
-        )}
+
+          {onExport && (
+            <button
+              type="button"
+              className="export-btn"
+              onClick={onExport}
+            >
+              Export as PDF
+            </button>
+          )}
+        </div>
       </div>
     </form>
   );

--- a/src/routes/Meal/PersonalizedWeeklyPlan.jsx
+++ b/src/routes/Meal/PersonalizedWeeklyPlan.jsx
@@ -1,5 +1,6 @@
 // src/routes/Meal/PersonalizedWeeklyPlan.jsx
 import { useEffect, useState } from 'react';
+import './PersonalizedPlan.css';
 
 const AI_ENDPOINT       = 'http://localhost/api/meal-plan/ai-generate';
 const FEEDBACK_ENDPOINT = (planId) => `http://localhost/api/meal-plan/feedback/${planId}`;


### PR DESCRIPTION
## Summary

- Adds a two-tab switcher (**Add Meal** / **AI Personalised Plan**) to the `/Meal` page so users can access the AI plan without navigating to a separate route
- Embeds `PersonalizedPlanForm` and `PersonalizedWeeklyPlan` directly inside the Meal page — form collects diet type, goals, calorie target, cuisine, health conditions, allergies, meal texture, mobility, cooking complexity, and portion size
- Creates `PersonalizedPlan.css` to fix previously unstyled classes (`chip`, `btn-primary-solid`, `personalize-card`, `personalize-input`, etc.) — chips and the generate button were invisible before this change
- Adds a prominent **generate bar** at the bottom of the form with helper text and a loading spinner state
- PDF export is wired through the existing `PersonalizedWeeklyPlan` export handler

## Test plan

- [ ] Navigate to `/Meal` and confirm two tabs appear below the breadcrumb
- [ ] Switch to **AI Personalised Plan** tab — form should render with visible chip buttons, styled inputs, and the generate bar at the bottom
- [ ] Select health conditions and allergies — chips should toggle blue/white correctly
- [ ] Submit the form — generate bar button should show loading spinner, then the 7-day plan renders below the form
- [ ] Click **Regenerate Plan** inside the weekly plan — plan refreshes with same filters
- [ ] Click **Export as PDF** — downloads `Personalized_Meal_Plan.pdf`
- [ ] Switch back to **Add Meal** tab — existing meal browsing, date picker, and nutrition sidebar all work as before
- [ ] Confirm no regressions on the existing Add Meal tab (search, filters, pagination, selection, widget FAB)