### PR TITLE
fix: restore activeTab and planFilters state lost during merge

### DIFF
--- a/src/routes/Meal/Meal.jsx
+++ b/src/routes/Meal/Meal.jsx
@@ -677,6 +677,9 @@ const Meal = () => {
     normalizeSelectionsByDate(readSelectionsByDateFromStorage()),
   );
 
+  const [activeTab, setActiveTab] = useState('addMeal');
+  const [planFilters, setPlanFilters] = useState(null);
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [location.pathname, location.search]);


### PR DESCRIPTION
## Summary

- Restores two `useState` declarations (`activeTab`, `planFilters`) in `Meal.jsx` that were accidentally dropped when resolving the merge conflict between `feature/AI-meal-plan` and `master`
- Without these, the page threw `ReferenceError: activeTab is not defined` on load

## Root cause

When the merge conflict was resolved, the block containing the new state declarations was discarded in favour of master's `useEffect` hooks. Both needed to be kept — this PR adds the missing two lines back.

## Test plan

- [ ] Navigate to `/Meal` — page loads without runtime errors
- [ ] Both tabs (Add Meal / AI Personalised Plan) render and switch correctly
- [ ] No regressions on existing meal browsing functionality