### PR TITLE
AI012: Improve chat_with_rag retrieval and domain-safe fallback (remove RAG toggle and use chat production route in Nutrihelp_Web))

### DIFF
--- a/src/routes/chat/ChatPage.css
+++ b/src/routes/chat/ChatPage.css
@@ -172,6 +172,12 @@
   font-weight: 700;
 }
 
+.nh-chatTitle {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 3rem);
+  line-height: 1.1;
+}
+
 .nh-messages {
   flex: 1;
   padding: 18px;

--- a/src/routes/chat/ChatPage.jsx
+++ b/src/routes/chat/ChatPage.jsx
@@ -4,6 +4,7 @@ import "./ChatPage.css";
 
 /* ---------------- Config ---------------- */
 const AI_BASE_URL = "http://localhost:8000";
+const CHAT_ENDPOINT = `${AI_BASE_URL}/ai-model/chatbot/chat`;
 
 /* ---------------- Utils ---------------- */
 
@@ -25,7 +26,6 @@ export default function ChatPage() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [draft, setDraft] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [useRag, setUseRag] = useState(false);
   const messagesRef = useRef(null);
 
   const navLinks = useMemo(
@@ -81,11 +81,7 @@ export default function ChatPage() {
   }, []);
 
   async function callChatbot(userMessage) {
-    const endpoint = useRag
-      ? `${AI_BASE_URL}/ai-model/chatbot/chat_with_rag`
-      : `${AI_BASE_URL}/ai-model/chatbot/chat`;
-
-    const response = await fetch(endpoint, {
+    const response = await fetch(CHAT_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ query: userMessage }),
@@ -234,16 +230,8 @@ export default function ChatPage() {
       {/* ---------- Chat ---------- */}
       <main className="nh-app">
         <section className="nh-chatCard">
-          <div className="nh-chatHeader" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "8px" }}>
-            <h2 style={{ margin: 0 }}>NutriHelp Assistant</h2>
-            <label style={{ fontSize: "0.8rem", cursor: "pointer", color: "#666", display: "flex", alignItems: "center", gap: "6px" }}>
-              <input
-                type="checkbox"
-                checked={useRag}
-                onChange={(e) => setUseRag(e.target.checked)}
-              />
-              Use knowledge base (RAG)
-            </label>
+          <div className="nh-chatHeader">
+            <h2 className="nh-chatTitle">NutriHelp Assistant</h2>
           </div>
 
           <div className="nh-messages" ref={messagesRef}>


### PR DESCRIPTION
Summary
This PR simplifies the Assistant chat flow on the frontend by removing the manual RAG toggle from the UI and using `/chat` as the single production route.

Changes made
- removed the “Use knowledge base (RAG)” checkbox from the chat page
- updated the Assistant page to always call `/chat`
- aligned the frontend with the backend RAG-first + fallback logic
- simplified the production chat experience for users

Tested
- chat page builds successfully
- frontend no longer references `chat_with_rag` directly
- chatbot flow now relies on the backend smart route only
