### PR TITLE
Work with BE37 Audit Live Monitoring MVP

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ import Scan from "./routes/ScanBarcode/Scan.jsx"
 import MFAform from "./routes/MFA/MFAform";
 import Dashboard from "./routes/NewMenu/Dashboard";
 import AuthenticateRoute from "./routes/AuthenticateRoute/AuthenticateRoute";
+import InternalAdminRoute from "./routes/AuthenticateRoute/InternalAdminRoute";
 import MainNavbar from "./components/MainNavbar";
 import FAQ from "./routes/FAQ/faq";
 import NutritionCalculator from "./routes/UI-Only-Pages/NutritionCalculator/NutritionCalculator";
@@ -70,6 +71,7 @@ import AuthCallback from "./pages/AuthCallback";
 import DailyPlanEdit from "./routes/DailyPlan/DailyPlanEdit";
 import Account from "./routes/Account/Account.js";
 import TextToSpeechControl from "./components/TextToSpeech/TextToSpeech";
+import AdminAuditDashboard from "./routes/AdminAudit/AdminAuditDashboard";
 import { isAuthPath } from "./utils/ttsRouteUtils";
 /* -------------------------------
    GLOBAL AUTHENTICATED LAYOUT
@@ -385,6 +387,15 @@ function App() {
             <AuthenticateRoute>
               <Dashboard />
             </AuthenticateRoute>
+          }
+        />
+
+        <Route
+          path="/admin/integration-audit"
+          element={
+            <InternalAdminRoute>
+              <AdminAuditDashboard />
+            </InternalAdminRoute>
           }
         />
 

--- a/src/routes/AdminAudit/AdminAuditDashboard.css
+++ b/src/routes/AdminAudit/AdminAuditDashboard.css
@@ -1,0 +1,309 @@
+.admin-audit-shell {
+  min-height: 100vh;
+  padding: 112px 24px 48px;
+  background:
+    radial-gradient(circle at top left, rgba(45, 125, 105, 0.16), transparent 28%),
+    linear-gradient(180deg, #f5f8f6 0%, #edf3ef 100%);
+  color: #183328;
+}
+
+.admin-audit-hero,
+.admin-audit-summary-grid,
+.admin-audit-panels,
+.admin-audit-panel {
+  max-width: 1280px;
+  margin: 0 auto 20px;
+}
+
+.admin-audit-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: end;
+}
+
+.admin-audit-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.3rem);
+  line-height: 1;
+}
+
+.admin-audit-kicker {
+  margin: 0 0 8px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #2a7c66;
+}
+
+.admin-audit-subtitle,
+.admin-audit-muted {
+  color: #567469;
+}
+
+.admin-audit-repo-note {
+  margin-top: 6px;
+  max-width: 52ch;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  color: #476257;
+}
+
+.admin-audit-meta {
+  min-width: 220px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(24, 51, 40, 0.08);
+  backdrop-filter: blur(14px);
+}
+
+.admin-audit-meta span,
+.admin-audit-card-label,
+.admin-audit-card-hint {
+  display: block;
+}
+
+.admin-audit-meta-live {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 10px;
+  font-size: 0.82rem;
+  color: #567469;
+}
+
+.admin-audit-meta-debug {
+  margin-top: 10px;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: #6b867c;
+  word-break: break-all;
+}
+
+.admin-audit-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.admin-audit-card,
+.admin-audit-panel {
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.84);
+  border: 1px solid rgba(24, 51, 40, 0.08);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 20px 50px rgba(38, 73, 61, 0.08);
+}
+
+.admin-audit-card {
+  padding: 18px;
+}
+
+.admin-audit-card-label {
+  font-size: 0.8rem;
+  color: #567469;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.admin-audit-card-value {
+  display: block;
+  margin: 8px 0 4px;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.admin-audit-card-hint {
+  font-size: 0.9rem;
+  color: #6b867c;
+}
+
+.admin-audit-refresh-button {
+  border: 1px solid rgba(24, 51, 40, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  color: #183328;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.admin-audit-refresh-button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+.admin-audit-panels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.admin-audit-panel {
+  padding: 22px;
+}
+
+.admin-audit-panel h2 {
+  margin: 0 0 16px;
+  font-size: 1.15rem;
+}
+
+.admin-audit-list,
+.admin-audit-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.admin-audit-list-row,
+.admin-audit-ai-row,
+.admin-audit-error-head,
+.admin-audit-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.admin-audit-filter-group {
+  display: inline-flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.admin-audit-filter-button {
+  border: 1px solid rgba(24, 51, 40, 0.12);
+  background: rgba(255, 255, 255, 0.82);
+  color: #35594b;
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+}
+
+.admin-audit-filter-button.is-active {
+  background: #183328;
+  color: #f7fbf8;
+  border-color: #183328;
+}
+
+.admin-audit-error-row {
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: #f6faf7;
+  border: 1px solid rgba(24, 51, 40, 0.06);
+}
+
+.admin-audit-mini-list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: #26493d;
+}
+
+.admin-audit-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.admin-audit-pill-connected,
+.admin-audit-pill-available,
+.admin-audit-pill-live,
+.admin-audit-pill-running,
+.admin-audit-pill-success {
+  background: #def5e8;
+  color: #177245;
+}
+
+.admin-audit-pill-empty-or-ui-only,
+.admin-audit-pill-ai-direct,
+.admin-audit-pill-code-only {
+  background: #fff1d6;
+  color: #9a6700;
+}
+
+.admin-audit-pill-backend-mismatch,
+.admin-audit-pill-missing,
+.admin-audit-pill-not-loaded,
+.admin-audit-pill-not-running,
+.admin-audit-pill-servererror {
+  background: #ffe1dd;
+  color: #af3029;
+}
+
+.admin-audit-pill-clienterror,
+.admin-audit-pill-unknown {
+  background: #e8edf0;
+  color: #4a5961;
+}
+
+.admin-audit-health-block {
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: #f6faf7;
+  border: 1px solid rgba(24, 51, 40, 0.06);
+}
+
+.admin-audit-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-audit-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.94rem;
+}
+
+.admin-audit-table th,
+.admin-audit-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(24, 51, 40, 0.08);
+  text-align: left;
+  vertical-align: top;
+}
+
+.admin-audit-table th {
+  font-size: 0.78rem;
+  color: #567469;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.admin-audit-state {
+  max-width: 1280px;
+  margin: 0 auto 20px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.admin-audit-state-error {
+  border: 1px solid rgba(175, 48, 41, 0.15);
+  color: #af3029;
+}
+
+@media (max-width: 960px) {
+  .admin-audit-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-audit-hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-audit-meta {
+    min-width: 0;
+    width: 100%;
+  }
+}

--- a/src/routes/AdminAudit/AdminAuditDashboard.jsx
+++ b/src/routes/AdminAudit/AdminAuditDashboard.jsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useMemo, useState } from "react";
+import adminAuditApi from "../../services/adminAuditApi";
+import "./AdminAuditDashboard.css";
+
+const FALLBACK_REFRESH_MS = 30000;
+
+function formatDateTime(value) {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleString();
+  } catch (_error) {
+    return String(value);
+  }
+}
+
+function StatusPill({ value }) {
+  const normalized = String(value || "unknown").toLowerCase();
+  const label = normalized.replace(/-/g, " ");
+  return <span className={`admin-audit-pill admin-audit-pill-${normalized}`}>{label}</span>;
+}
+
+function getRepositoryStatus(repo) {
+  if (repo?.status) return String(repo.status).toLowerCase();
+  if (!repo?.available) return "not-loaded";
+
+  if (repo?.key === "mobile") return "code-only";
+  if (repo?.key === "ai") return "not-running";
+  if (repo?.key === "api") return "running";
+  if (repo?.key === "web") return "code-only";
+
+  return "unknown";
+}
+
+function formatRepoStatusHint(repo) {
+  if (!repo) return "—";
+
+  const parts = [];
+  const normalizedStatus = getRepositoryStatus(repo);
+
+  if (repo.note) {
+    parts.push(repo.note);
+  } else if (normalizedStatus === "not-loaded") {
+    parts.push("Repository is not present in the current workspace.");
+  } else if (normalizedStatus === "not-running") {
+    parts.push("Source is present, but no responding local runtime was detected.");
+  } else if (normalizedStatus === "code-only") {
+    parts.push("Source is available for audit, but this tool has not detected a live runtime.");
+  } else if (normalizedStatus === "running") {
+    parts.push("Repository source is available and the expected local runtime is responding.");
+  }
+
+  if (repo.runtimeUrl) {
+    parts.push(
+      repo.runtimeReachable === true
+        ? `Runtime reachable at ${repo.runtimeUrl}`
+        : `Expected runtime: ${repo.runtimeUrl}`
+    );
+  }
+
+  return parts.join(" ");
+}
+
+function SummaryCard({ label, value, hint }) {
+  return (
+    <article className="admin-audit-card">
+      <span className="admin-audit-card-label">{label}</span>
+      <strong className="admin-audit-card-value">{value}</strong>
+      {hint ? <span className="admin-audit-card-hint">{hint}</span> : null}
+    </article>
+  );
+}
+
+const AdminAuditDashboard = () => {
+  const [overview, setOverview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState("");
+  const [repositoryFilter, setRepositoryFilter] = useState("all");
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId = null;
+
+    const load = async ({ silent = false } = {}) => {
+      if (!silent) {
+        setLoading(true);
+      } else {
+        setRefreshing(true);
+      }
+
+      if (!silent) {
+        setError("");
+      }
+
+      try {
+        const data = await adminAuditApi.getLiveOverview();
+        if (!cancelled) {
+          setOverview(data);
+        }
+      } catch (loadError) {
+        if (!cancelled && !silent) {
+          const details = [
+            loadError.message || "Failed to load admin audit overview",
+            "Expected API: http://127.0.0.1:8081/api/system/dev/live-audit/overview",
+          ].join(" ");
+          setError(details);
+        }
+      } finally {
+        if (!cancelled) {
+          if (!silent) {
+            setLoading(false);
+          } else {
+            setRefreshing(false);
+          }
+        }
+      }
+    };
+
+    load();
+
+    const refreshIntervalMs =
+      overview?.live?.refreshIntervalMs || FALLBACK_REFRESH_MS;
+
+    intervalId = window.setInterval(() => {
+      load({ silent: true });
+    }, refreshIntervalMs);
+
+    return () => {
+      cancelled = true;
+      if (intervalId) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [overview?.live?.refreshIntervalMs]);
+
+  const handleManualRefresh = async () => {
+    setRefreshing(true);
+    setError("");
+    try {
+      const data = await adminAuditApi.refreshLiveOverview();
+      setOverview(data);
+    } catch (refreshError) {
+      setError(refreshError.message || "Failed to refresh live audit overview");
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const repositorySummary = useMemo(() => overview?.repositories || [], [overview]);
+  const filteredRepositorySummary = useMemo(() => {
+    if (repositoryFilter !== "attention") return repositorySummary;
+    return repositorySummary.filter(
+      (repo) => {
+        const status = getRepositoryStatus(repo);
+        return status === "not-loaded" || status === "not-running";
+      }
+    );
+  }, [repositoryFilter, repositorySummary]);
+  const routeAudit = useMemo(() => overview?.routeAudit || [], [overview]);
+  const recentErrors = useMemo(() => overview?.recentErrors || [], [overview]);
+  const unusedBackendRoutes = useMemo(() => overview?.unusedRoutes?.backend || [], [overview]);
+  const emptyFrontendRoutes = useMemo(() => overview?.unusedRoutes?.frontend || [], [overview]);
+  const aiServices = useMemo(() => Object.values(overview?.health?.aiServices || {}), [overview]);
+
+  return (
+    <main className="admin-audit-shell">
+      <section className="admin-audit-hero">
+        <div>
+          <p className="admin-audit-kicker">Internal Tool</p>
+          <h1>Integration Audit Dashboard</h1>
+          <p className="admin-audit-subtitle">
+            Internal visibility across frontend routes, backend endpoints, AI service usage, and recent failures.
+          </p>
+        </div>
+        <div className="admin-audit-meta">
+          <span>Generated</span>
+          <strong>{formatDateTime(overview?.generatedAt)}</strong>
+          <div className="admin-audit-meta-live">
+            <StatusPill value={overview?.live?.mode || "live"} />
+            <span>Last checked {formatDateTime(overview?.live?.lastRunAt || overview?.generatedAt)}</span>
+          </div>
+          <div className="admin-audit-meta-live">
+            <span>Refresh every {(overview?.live?.refreshIntervalMs || FALLBACK_REFRESH_MS) / 1000}s</span>
+            <button
+              type="button"
+              className="admin-audit-refresh-button"
+              onClick={handleManualRefresh}
+              disabled={refreshing}
+            >
+              {refreshing ? "Refreshing..." : "Refresh now"}
+            </button>
+          </div>
+          {overview?.__debug?.endpoint ? (
+            <div className="admin-audit-meta-debug">{overview.__debug.endpoint}</div>
+          ) : null}
+        </div>
+      </section>
+
+      {loading ? <div className="admin-audit-state">Loading live dashboard…</div> : null}
+      {error ? <div className="admin-audit-state admin-audit-state-error">{error}</div> : null}
+
+      {!loading && !error && overview ? (
+        <>
+          <section className="admin-audit-summary-grid">
+            <SummaryCard label="Frontend Routes" value={overview.summary.totalFrontendRoutes} />
+            <SummaryCard label="Backend Endpoints" value={overview.summary.totalBackendRoutes} />
+            <SummaryCard label="Connected Routes" value={overview.summary.connectedRoutes} />
+            <SummaryCard label="Chatbot API Requests" value={overview.summary.chatbotRequests} hint={`AI calls: ${overview.summary.chatbotAiCalls}`} />
+            <SummaryCard label="Recent Errors" value={overview.summary.recentErrorCount} />
+            <SummaryCard label="Unused Backend Routes" value={overview.summary.unusedBackendRoutes} hint={`Empty frontend routes: ${overview.summary.emptyFrontendRoutes}`} />
+            <SummaryCard label="Repos Running" value={overview.summary.repositoriesRunning} hint={`Code only: ${overview.summary.repositoriesCodeOnly}`} />
+            <SummaryCard label="Repos Attention Needed" value={overview.summary.repositoriesNotLoaded + overview.summary.repositoriesNotRunning} hint={`Not loaded: ${overview.summary.repositoriesNotLoaded} • Not running: ${overview.summary.repositoriesNotRunning}`} />
+          </section>
+
+          <section className="admin-audit-panels">
+            <article className="admin-audit-panel">
+              <div className="admin-audit-panel-header">
+                <h2>Repository Status</h2>
+                <div className="admin-audit-filter-group">
+                  <button
+                    type="button"
+                    className={`admin-audit-filter-button ${repositoryFilter === "all" ? "is-active" : ""}`}
+                    onClick={() => setRepositoryFilter("all")}
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    className={`admin-audit-filter-button ${repositoryFilter === "attention" ? "is-active" : ""}`}
+                    onClick={() => setRepositoryFilter("attention")}
+                  >
+                    Attention only
+                  </button>
+                </div>
+              </div>
+              <div className="admin-audit-list">
+                {filteredRepositorySummary.length === 0 ? (
+                  <div className="admin-audit-muted">No repositories match the current filter.</div>
+                ) : filteredRepositorySummary.map((repo) => (
+                  <div key={repo.key} className="admin-audit-list-row">
+                    <div>
+                      <strong>{repo.name}</strong>
+                      <div className="admin-audit-muted">{repo.path || "Repository not found in current workspace"}</div>
+                      <div className="admin-audit-repo-note">{formatRepoStatusHint(repo)}</div>
+                    </div>
+                    <StatusPill value={getRepositoryStatus(repo)} />
+                  </div>
+                ))}
+              </div>
+            </article>
+
+            <article className="admin-audit-panel">
+              <h2>Service Health</h2>
+              <div className="admin-audit-stack">
+                <div className="admin-audit-health-block">
+                  <strong>API Runtime</strong>
+                  <div className="admin-audit-muted">Started: {formatDateTime(overview.health.api.requestAuditStartedAt)}</div>
+                  <div className="admin-audit-muted">Tracked requests: {overview.health.api.runtimeRequestCount}</div>
+                </div>
+                <div className="admin-audit-health-block">
+                  <strong>Error Logging</strong>
+                  <div className="admin-audit-muted">Overall: {String(overview.health.errorLogging?.overall)}</div>
+                  <div className="admin-audit-muted">Database: {String(overview.health.errorLogging?.database)}</div>
+                  <div className="admin-audit-muted">File: {String(overview.health.errorLogging?.file)}</div>
+                </div>
+                <div className="admin-audit-health-block">
+                  <strong>AI Services</strong>
+                  {aiServices.length === 0 ? (
+                    <div className="admin-audit-muted">No AI traffic recorded since process start.</div>
+                  ) : (
+                    aiServices.map((service) => (
+                      <div key={service.service} className="admin-audit-ai-row">
+                        <span>{service.service}</span>
+                        <span>{service.calls} calls</span>
+                        <span>{service.successRate} success</span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </article>
+          </section>
+
+          <section className="admin-audit-panels">
+            <article className="admin-audit-panel">
+              <h2>Recent Errors</h2>
+              <div className="admin-audit-list">
+                {recentErrors.length === 0 ? (
+                  <div className="admin-audit-muted">No recent error logs found.</div>
+                ) : (
+                  recentErrors.map((entry, index) => (
+                    <div key={`${entry.timestamp || entry.at || "error"}-${index}`} className="admin-audit-error-row">
+                      <div className="admin-audit-error-head">
+                        <strong>{entry.message || entry.error_message || "Unknown error"}</strong>
+                        <span>{formatDateTime(entry.timestamp || entry.created_at || entry.at)}</span>
+                      </div>
+                      <div className="admin-audit-muted">
+                        {entry.category || entry.type || "unknown"} {entry.code ? `• ${entry.code}` : ""}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </article>
+
+            <article className="admin-audit-panel">
+              <h2>Unused or Empty Routes</h2>
+              <div className="admin-audit-stack">
+                <div>
+                  <strong>Empty Frontend Routes</strong>
+                  <ul className="admin-audit-mini-list">
+                    {emptyFrontendRoutes.length === 0 ? <li>None</li> : emptyFrontendRoutes.map((route) => <li key={route.frontendRoute}>{route.frontendRoute}</li>)}
+                  </ul>
+                </div>
+                <div>
+                  <strong>Unused Backend Routes</strong>
+                  <ul className="admin-audit-mini-list">
+                    {unusedBackendRoutes.length === 0 ? <li>None</li> : unusedBackendRoutes.slice(0, 12).map((route) => <li key={route.mountPath}>{route.mountPath}</li>)}
+                  </ul>
+                </div>
+              </div>
+            </article>
+          </section>
+
+          <section className="admin-audit-panel">
+            <div className="admin-audit-panel-header">
+              <h2>Route Audit Table</h2>
+              <span>{routeAudit.length} frontend routes scanned</span>
+            </div>
+            <div className="admin-audit-table-wrap">
+              <table className="admin-audit-table">
+                <thead>
+                  <tr>
+                    <th>Frontend Route</th>
+                    <th>Component File</th>
+                    <th>Backend APIs</th>
+                    <th>AI Services</th>
+                    <th>Status</th>
+                    <th>Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {routeAudit.map((row) => (
+                    <tr key={`${row.frontendRoute}-${row.componentName}`}>
+                      <td>{row.frontendRoute}</td>
+                      <td>{row.componentFile || row.componentName}</td>
+                      <td>
+                        {row.backendApis.length === 0 ? "—" : row.backendApis.join(", ")}
+                      </td>
+                      <td>
+                        {row.aiServices.length === 0 ? "—" : row.aiServices.join(", ")}
+                      </td>
+                      <td><StatusPill value={row.status} /></td>
+                      <td>{row.notes || "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </main>
+  );
+};
+
+export default AdminAuditDashboard;

--- a/src/routes/AuthenticateRoute/InternalAdminRoute.jsx
+++ b/src/routes/AuthenticateRoute/InternalAdminRoute.jsx
@@ -1,0 +1,32 @@
+import React, { useContext } from "react";
+import { Navigate } from "react-router-dom";
+import { UserContext } from "../../context/user.context";
+
+function allowLocalDevAccess() {
+  if (process.env.NODE_ENV === "production") return false;
+  if (typeof window === "undefined") return false;
+
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1";
+}
+
+const InternalAdminRoute = ({ children }) => {
+  const { currentUser } = useContext(UserContext);
+
+  if (allowLocalDevAccess()) {
+    return children;
+  }
+
+  if (!currentUser) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const role = String(currentUser.role || "").toLowerCase();
+  if (role !== "admin") {
+    return <Navigate to="/home" replace />;
+  }
+
+  return children;
+};
+
+export default InternalAdminRoute;

--- a/src/services/adminAuditApi.js
+++ b/src/services/adminAuditApi.js
@@ -1,0 +1,95 @@
+import BaseApi from "./baseApi";
+
+function isLocalDevAuditMode() {
+  if (process.env.NODE_ENV === "production") return false;
+  if (typeof window === "undefined") return false;
+
+  const host = window.location.hostname;
+  return host === "localhost" || host === "127.0.0.1";
+}
+
+function getLocalDevBaseURL() {
+  if (typeof window === "undefined") {
+    return "http://localhost:8081/api";
+  }
+
+  const host = window.location.hostname || "localhost";
+  return `http://${host}:8081/api`;
+}
+
+class AdminAuditApi extends BaseApi {
+  async getOverview() {
+    return this.getLiveOverview();
+  }
+
+  async getLiveOverview() {
+    const useDevLocalEndpoint = isLocalDevAuditMode();
+    const token = useDevLocalEndpoint ? null : this.getAuthToken();
+    const baseURL = useDevLocalEndpoint ? getLocalDevBaseURL() : this.baseURL;
+    const endpoint = useDevLocalEndpoint
+      ? `${baseURL}/system/dev/live-audit/overview`
+      : `${baseURL}/system/live-audit/overview`;
+    const headers = {};
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(endpoint, {
+      method: "GET",
+      headers,
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok || !payload?.success) {
+      throw new Error(payload?.error || "Failed to load integration audit overview");
+    }
+
+    return {
+      ...payload.data,
+      __debug: {
+        endpoint,
+        mode: useDevLocalEndpoint ? "dev-live" : "authenticated-live",
+      },
+    };
+  }
+
+  async refreshLiveOverview() {
+    const useDevLocalEndpoint = isLocalDevAuditMode();
+
+    if (useDevLocalEndpoint) {
+      return this.getLiveOverview();
+    }
+
+    const token = this.getAuthToken();
+    const endpoint = `${this.baseURL}/system/live-audit/run`;
+    const headers = {};
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok || !payload?.success) {
+      throw new Error(payload?.error || "Failed to refresh live integration audit overview");
+    }
+
+    return {
+      ...payload.data,
+      __debug: {
+        endpoint,
+        mode: "authenticated-live-refresh",
+      },
+    };
+  }
+}
+
+export const adminAuditApi = new AdminAuditApi();
+export default adminAuditApi;


### PR DESCRIPTION
## Summary
Adds the internal integration audit dashboard UI to `Nutrihelp-web`. This introduces a dedicated internal route for the dashboard, a local-development access path that does not require end-user login, a live audit API client, and a dashboard interface that displays repository status, route connections, recent errors, unused routes, and live refresh metadata. The dashboard now consumes the live audit data exposed by `Nutrihelp-api` and supports periodic refresh plus manual refresh.

## Why it needed
The project now spans multiple repositories, and it has become increasingly difficult to understand how frontend routes connect to backend APIs and AI services without manually tracing code across repos. This creates debugging friction and makes broken integrations harder to spot quickly. The web-side dashboard provides a single internal place for developers to inspect route wiring, runtime status, audit notes, and integration gaps without relying on scattered local knowledge or manual code searching.

## Testing
- Built the frontend successfully with:
  - `npm run build`
- Confirmed the dashboard route is available:
  - `/admin/integration-audit`
- Verified the dashboard is wired to the live audit API endpoint from `Nutrihelp-api`
- Confirmed the UI supports:
  - live auto-refresh
  - manual refresh
  - repository status display
  - “Attention only” filtering
  - direct frontend-to-AI routes showing as `connected` with explanatory notes
- The build completed successfully; only existing repository warnings remained (CRA/Babel, `html2pdf.js` source map, and existing CSS autoprefixer warnings)

If the web dashboard fails with missing webpack/html-webpack-plugin modules, run npm install in Nutrihelp-web first.
