### PR TITLE
Work with BE38 Audit route drill-down and data quality

### DIFF
--- a/src/routes/AdminAudit/AdminAuditDashboard.css
+++ b/src/routes/AdminAudit/AdminAuditDashboard.css
@@ -199,6 +199,92 @@
   border: 1px solid rgba(24, 51, 40, 0.06);
 }
 
+.admin-audit-detail-panel {
+  display: grid;
+  gap: 20px;
+}
+
+.admin-audit-contract-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-audit-detail-statuses {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.admin-audit-flow-grid,
+.admin-audit-layer-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.admin-audit-flow-column,
+.admin-audit-layer-card {
+  padding: 16px;
+  border-radius: 18px;
+  background: #f6faf7;
+  border: 1px solid rgba(24, 51, 40, 0.06);
+}
+
+.admin-audit-flow-label {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #2a7c66;
+}
+
+.admin-audit-flow-block + .admin-audit-flow-block {
+  margin-top: 12px;
+}
+
+.admin-audit-flow-head,
+.admin-audit-layer-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.admin-audit-flow-tags,
+.admin-audit-row-layer-pills {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.admin-audit-flow-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(42, 124, 102, 0.1);
+  color: #1b5a48;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.admin-audit-layer-issues {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: #26493d;
+}
+
+.admin-audit-related-failures {
+  display: grid;
+  gap: 12px;
+}
+
 .admin-audit-mini-list {
   margin: 10px 0 0;
   padding-left: 18px;
@@ -247,6 +333,49 @@
   color: #4a5961;
 }
 
+.admin-audit-pill-healthy {
+  background: #def5e8;
+  color: #177245;
+}
+
+.admin-audit-pill-warning,
+.admin-audit-pill-idle,
+.admin-audit-pill-not-applicable {
+  background: #fff1d6;
+  color: #9a6700;
+}
+
+.admin-audit-pill-critical,
+.admin-audit-pill-frontend,
+.admin-audit-pill-api,
+.admin-audit-pill-ai {
+  background: #ffe1dd;
+  color: #af3029;
+}
+
+.admin-audit-pill-direct-ai,
+.admin-audit-pill-public {
+  background: #def5e8;
+  color: #177245;
+}
+
+.admin-audit-pill-degraded,
+.admin-audit-pill-bad-data,
+.admin-audit-pill-stale,
+.admin-audit-pill-requires-auth,
+.admin-audit-pill-requires-admin,
+.admin-audit-pill-partial {
+  background: #fff1d6;
+  color: #9a6700;
+}
+
+.admin-audit-pill-contract-mismatch,
+.admin-audit-pill-missing-required-fields,
+.admin-audit-pill-renamed-fields-detected {
+  background: #ffe1dd;
+  color: #af3029;
+}
+
 .admin-audit-health-block {
   padding: 14px 16px;
   border-radius: 18px;
@@ -256,6 +385,41 @@
 
 .admin-audit-table-wrap {
   overflow-x: auto;
+}
+
+.admin-audit-table tbody tr {
+  cursor: pointer;
+  transition: background 140ms ease;
+}
+
+.admin-audit-table tbody tr:hover {
+  background: rgba(42, 124, 102, 0.05);
+}
+
+.admin-audit-table tbody tr.is-selected {
+  background: rgba(42, 124, 102, 0.1);
+}
+
+.admin-audit-sample-preview {
+  margin: 12px 0 0;
+  padding: 12px;
+  border-radius: 14px;
+  background: #eef4f0;
+  color: #183328;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
+}
+
+@media (max-width: 980px) {
+  .admin-audit-flow-grid,
+  .admin-audit-layer-grid,
+  .admin-audit-panels {
+    grid-template-columns: 1fr;
+  }
 }
 
 .admin-audit-table {

--- a/src/routes/AdminAudit/AdminAuditDashboard.jsx
+++ b/src/routes/AdminAudit/AdminAuditDashboard.jsx
@@ -70,12 +70,120 @@ function SummaryCard({ label, value, hint }) {
   );
 }
 
+function buildRouteKey(route) {
+  return `${route.frontendRoute}::${route.componentName}`;
+}
+
+function LayerStatusCard({ label, layer }) {
+  if (!layer) return null;
+
+  return (
+    <div className="admin-audit-layer-card">
+      <div className="admin-audit-layer-card-head">
+        <strong>{label}</strong>
+        <StatusPill value={layer.status || "unknown"} />
+      </div>
+      {layer.issues?.length ? (
+        <ul className="admin-audit-layer-issues">
+          {layer.issues.map((issue) => (
+            <li key={`${label}-${issue}`}>{issue}</li>
+          ))}
+        </ul>
+      ) : (
+        <div className="admin-audit-muted">No active issues detected for this layer.</div>
+      )}
+    </div>
+  );
+}
+
+function ClassificationTags({ values = [] }) {
+  if (!values.length) {
+    return <span className="admin-audit-muted">No extra classifications.</span>;
+  }
+
+  return (
+    <div className="admin-audit-flow-tags">
+      {values.map((value) => (
+        <StatusPill key={value} value={value} />
+      ))}
+    </div>
+  );
+}
+
+function ContractValidationCard({ entry }) {
+  if (!entry) return null;
+
+  return (
+    <div className="admin-audit-layer-card">
+      <div className="admin-audit-layer-card-head">
+        <strong>{entry.endpoint}</strong>
+        <StatusPill value={entry.status || "unknown"} />
+      </div>
+      <div className="admin-audit-muted">Required: {entry.requiredFields?.length ? entry.requiredFields.join(", ") : "—"}</div>
+      <div className="admin-audit-muted">
+        Missing: {entry.missingFields?.length ? entry.missingFields.join(", ") : "None"}
+      </div>
+      <div className="admin-audit-muted">
+        Optional missing: {entry.optionalMissingFields?.length ? entry.optionalMissingFields.join(", ") : "None"}
+      </div>
+      <div className="admin-audit-muted">
+        Aliases detected: {entry.detectedAliases?.length ? entry.detectedAliases.join(", ") : "None"}
+      </div>
+      {entry.renamedFields?.length ? (
+        <ul className="admin-audit-layer-issues">
+          {entry.renamedFields.map((item) => (
+            <li key={`${entry.endpoint}-${item.expectedField}`}>
+              Expected <code>{item.expectedField}</code> but found alias {item.detectedAliases.join(", ")}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function DataQualityCard({ entry }) {
+  if (!entry) return null;
+
+  return (
+    <div className="admin-audit-layer-card">
+      <div className="admin-audit-layer-card-head">
+        <strong>{entry.endpoint}</strong>
+        <StatusPill value={entry.status || "unknown"} />
+      </div>
+      <div className="admin-audit-muted">Captured: {formatDateTime(entry.capturedAt)}</div>
+      <div className="admin-audit-muted">
+        Missing values: {entry.missingValues?.length ? entry.missingValues.join(", ") : "None"}
+      </div>
+      <div className="admin-audit-muted">
+        Empty arrays: {entry.emptyArrays?.length ? entry.emptyArrays.join(", ") : "None"}
+      </div>
+      <div className="admin-audit-muted">
+        Blank strings: {entry.blankStrings?.length ? entry.blankStrings.join(", ") : "None"}
+      </div>
+      {entry.notes?.length ? (
+        <ul className="admin-audit-layer-issues">
+          {entry.notes.map((note) => (
+            <li key={`${entry.endpoint}-${note}`}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+      {entry.sampleBody ? (
+        <pre className="admin-audit-sample-preview">
+          {JSON.stringify(entry.sampleBody, null, 2)}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
 const AdminAuditDashboard = () => {
   const [overview, setOverview] = useState(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState("");
   const [repositoryFilter, setRepositoryFilter] = useState("all");
+  const [selectedRouteKey, setSelectedRouteKey] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -157,10 +265,25 @@ const AdminAuditDashboard = () => {
     );
   }, [repositoryFilter, repositorySummary]);
   const routeAudit = useMemo(() => overview?.routeAudit || [], [overview]);
+  const selectedRoute = useMemo(
+    () => routeAudit.find((route) => buildRouteKey(route) === selectedRouteKey) || routeAudit[0] || null,
+    [routeAudit, selectedRouteKey]
+  );
   const recentErrors = useMemo(() => overview?.recentErrors || [], [overview]);
   const unusedBackendRoutes = useMemo(() => overview?.unusedRoutes?.backend || [], [overview]);
   const emptyFrontendRoutes = useMemo(() => overview?.unusedRoutes?.frontend || [], [overview]);
   const aiServices = useMemo(() => Object.values(overview?.health?.aiServices || {}), [overview]);
+
+  useEffect(() => {
+    if (!routeAudit.length) {
+      if (selectedRouteKey) setSelectedRouteKey("");
+      return;
+    }
+
+    if (!selectedRouteKey || !routeAudit.some((route) => buildRouteKey(route) === selectedRouteKey)) {
+      setSelectedRouteKey(buildRouteKey(routeAudit[0]));
+    }
+  }, [routeAudit, selectedRouteKey]);
 
   return (
     <main className="admin-audit-shell">
@@ -205,11 +328,14 @@ const AdminAuditDashboard = () => {
             <SummaryCard label="Frontend Routes" value={overview.summary.totalFrontendRoutes} />
             <SummaryCard label="Backend Endpoints" value={overview.summary.totalBackendRoutes} />
             <SummaryCard label="Connected Routes" value={overview.summary.connectedRoutes} />
+            <SummaryCard label="Direct AI Routes" value={overview.summary.directAiRoutes} hint={`Requires auth: ${overview.summary.requiresAuthRoutes}`} />
+            <SummaryCard label="Degraded Routes" value={overview.summary.degradedRoutes} hint={`Contract mismatch: ${overview.summary.contractMismatchRoutes}`} />
+            <SummaryCard label="Bad Data Routes" value={overview.summary.badDataRoutes} hint="Captured runtime samples with missing or empty payload fields" />
             <SummaryCard label="Chatbot API Requests" value={overview.summary.chatbotRequests} hint={`AI calls: ${overview.summary.chatbotAiCalls}`} />
             <SummaryCard label="Recent Errors" value={overview.summary.recentErrorCount} />
             <SummaryCard label="Unused Backend Routes" value={overview.summary.unusedBackendRoutes} hint={`Empty frontend routes: ${overview.summary.emptyFrontendRoutes}`} />
             <SummaryCard label="Repos Running" value={overview.summary.repositoriesRunning} hint={`Code only: ${overview.summary.repositoriesCodeOnly}`} />
-            <SummaryCard label="Repos Attention Needed" value={overview.summary.repositoriesNotLoaded + overview.summary.repositoriesNotRunning} hint={`Not loaded: ${overview.summary.repositoriesNotLoaded} • Not running: ${overview.summary.repositoriesNotRunning}`} />
+            <SummaryCard label="Repos Attention Needed" value={overview.summary.repositoriesNotLoaded + overview.summary.repositoriesNotRunning} hint={`Not loaded: ${overview.summary.repositoriesNotLoaded} • Not running: ${overview.summary.repositoriesNotRunning} • Stale routes: ${overview.summary.staleRoutes}`} />
           </section>
 
           <section className="admin-audit-panels">
@@ -295,7 +421,7 @@ const AdminAuditDashboard = () => {
                         <span>{formatDateTime(entry.timestamp || entry.created_at || entry.at)}</span>
                       </div>
                       <div className="admin-audit-muted">
-                        {entry.category || entry.type || "unknown"} {entry.code ? `• ${entry.code}` : ""}
+                        <StatusPill value={entry.layer || "unknown"} /> {entry.category || entry.type || "unknown"} {entry.code ? `• ${entry.code}` : ""}
                       </div>
                     </div>
                   ))
@@ -322,6 +448,150 @@ const AdminAuditDashboard = () => {
             </article>
           </section>
 
+          {selectedRoute ? (
+            <section className="admin-audit-panel admin-audit-detail-panel">
+              <div className="admin-audit-panel-header">
+                <div>
+                  <h2>Route Flow Detail</h2>
+                  <div className="admin-audit-muted">
+                    {selectedRoute.frontendRoute} • {selectedRoute.componentFile || selectedRoute.componentName}
+                  </div>
+                </div>
+                <div className="admin-audit-detail-statuses">
+                  <StatusPill value={selectedRoute.status} />
+                  <span className="admin-audit-muted">
+                    API activity {selectedRoute.activity?.totalApiRequests || 0} • AI calls {selectedRoute.activity?.totalAiCalls || 0}
+                  </span>
+                </div>
+              </div>
+
+              <div className="admin-audit-flow-grid">
+                <div className="admin-audit-flow-column">
+                  <span className="admin-audit-flow-label">Frontend</span>
+                  <strong>{selectedRoute.componentName}</strong>
+                  <div className="admin-audit-muted">{selectedRoute.componentFile || "Component file unavailable"}</div>
+                  <div className="admin-audit-flow-tags">
+                    <span className="admin-audit-flow-tag">{selectedRoute.frontendRoute}</span>
+                  </div>
+                </div>
+
+                <div className="admin-audit-flow-column">
+                  <span className="admin-audit-flow-label">API</span>
+                  {selectedRoute.flow?.api?.length ? (
+                    selectedRoute.flow.api.map((entry) => (
+                      <div key={entry.endpoint} className="admin-audit-flow-block">
+                        <div className="admin-audit-flow-head">
+                          <strong>{entry.endpoint}</strong>
+                          <StatusPill value={entry.status} />
+                        </div>
+                        <div className="admin-audit-muted">
+                          {entry.group} • {entry.moduleFile || "No module file"}
+                        </div>
+                        <div className="admin-audit-muted">
+                          Requests: {entry.requestStats?.total || 0} • Last status: {entry.requestStats?.lastStatusCode || "—"} • Last seen: {formatDateTime(entry.requestStats?.lastCalledAt)}
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="admin-audit-muted">No backend hop detected for this route.</div>
+                  )}
+                </div>
+
+                <div className="admin-audit-flow-column">
+                  <span className="admin-audit-flow-label">AI</span>
+                  {selectedRoute.flow?.ai?.length ? (
+                    selectedRoute.flow.ai.map((entry) => (
+                      <div key={entry.endpoint} className="admin-audit-flow-block">
+                        <div className="admin-audit-flow-head">
+                          <strong>{entry.endpoint}</strong>
+                          <StatusPill value={entry.status} />
+                        </div>
+                        <div className="admin-audit-muted">
+                          Services: {entry.services?.length ? entry.services.join(", ") : "No monitor match yet"}
+                        </div>
+                        <div className="admin-audit-muted">
+                          Calls: {entry.totalCalls || 0} • Failures: {entry.failures || 0} • Last failure: {formatDateTime(entry.lastFailureAt)}
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="admin-audit-muted">No AI hop detected for this route.</div>
+                  )}
+                </div>
+              </div>
+
+              <div className="admin-audit-layer-grid">
+                <LayerStatusCard label="Frontend Layer" layer={selectedRoute.layerHealth?.frontend} />
+                <LayerStatusCard label="API Layer" layer={selectedRoute.layerHealth?.api} />
+                <LayerStatusCard label="AI Layer" layer={selectedRoute.layerHealth?.ai} />
+              </div>
+
+              <div className="admin-audit-layer-card">
+                <div className="admin-audit-layer-card-head">
+                  <strong>Classifications</strong>
+                  <StatusPill value={selectedRoute.authMode || "public"} />
+                </div>
+                <ClassificationTags values={selectedRoute.classifications || []} />
+              </div>
+
+              <div className="admin-audit-contract-grid">
+                <div className="admin-audit-panel-header">
+                  <strong>Contract Validation</strong>
+                  <span>{selectedRoute.contractValidation?.backend?.length || 0} backend contract checks</span>
+                </div>
+                {selectedRoute.contractValidation?.backend?.length ? (
+                  <div className="admin-audit-layer-grid">
+                    {selectedRoute.contractValidation.backend.map((entry) => (
+                      <ContractValidationCard key={entry.endpoint} entry={entry} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="admin-audit-muted">No backend contract checks apply to this route.</div>
+                )}
+              </div>
+
+              <div className="admin-audit-contract-grid">
+                <div className="admin-audit-panel-header">
+                  <strong>Runtime Data Quality</strong>
+                  <span>{selectedRoute.flow?.api?.length || 0} sampled endpoint checks</span>
+                </div>
+                {selectedRoute.flow?.api?.length ? (
+                  <div className="admin-audit-layer-grid">
+                    {selectedRoute.flow.api.map((entry) => (
+                      <DataQualityCard key={`${entry.endpoint}-data-quality`} entry={entry.dataQuality} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="admin-audit-muted">No backend data samples apply to this route yet.</div>
+                )}
+              </div>
+
+              <div className="admin-audit-related-failures">
+                <div className="admin-audit-panel-header">
+                  <strong>Related Failures</strong>
+                  <span>{selectedRoute.relatedFailures?.length || 0} linked signals</span>
+                </div>
+                {selectedRoute.relatedFailures?.length ? (
+                  <div className="admin-audit-list">
+                    {selectedRoute.relatedFailures.map((entry, index) => (
+                      <div key={`${entry.layer}-${entry.message}-${index}`} className="admin-audit-error-row">
+                        <div className="admin-audit-error-head">
+                          <strong>{entry.message}</strong>
+                          <span>{formatDateTime(entry.at)}</span>
+                        </div>
+                        <div className="admin-audit-muted">
+                          <StatusPill value={entry.layer} /> <StatusPill value={entry.status} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="admin-audit-muted">No route-specific failures are linked in the current snapshot.</div>
+                )}
+              </div>
+            </section>
+          ) : null}
+
           <section className="admin-audit-panel">
             <div className="admin-audit-panel-header">
               <h2>Route Audit Table</h2>
@@ -341,7 +611,11 @@ const AdminAuditDashboard = () => {
                 </thead>
                 <tbody>
                   {routeAudit.map((row) => (
-                    <tr key={`${row.frontendRoute}-${row.componentName}`}>
+                    <tr
+                      key={`${row.frontendRoute}-${row.componentName}`}
+                      className={buildRouteKey(row) === buildRouteKey(selectedRoute || {}) ? "is-selected" : ""}
+                      onClick={() => setSelectedRouteKey(buildRouteKey(row))}
+                    >
                       <td>{row.frontendRoute}</td>
                       <td>{row.componentFile || row.componentName}</td>
                       <td>
@@ -351,7 +625,19 @@ const AdminAuditDashboard = () => {
                         {row.aiServices.length === 0 ? "—" : row.aiServices.join(", ")}
                       </td>
                       <td><StatusPill value={row.status} /></td>
-                      <td>{row.notes || "—"}</td>
+                      <td>
+                        {row.notes || "—"}
+                        <div className="admin-audit-row-layer-pills">
+                          <StatusPill value={row.layerHealth?.frontend?.status || "unknown"} />
+                          <StatusPill value={row.layerHealth?.api?.status || "not-applicable"} />
+                          <StatusPill value={row.layerHealth?.ai?.status || "not-applicable"} />
+                        </div>
+                        <div className="admin-audit-row-layer-pills">
+                          {(row.classifications || []).map((value) => (
+                            <StatusPill key={`${row.frontendRoute}-${value}`} value={value} />
+                          ))}
+                        </div>
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/src/services/adminAuditApi.js
+++ b/src/services/adminAuditApi.js
@@ -59,7 +59,25 @@ class AdminAuditApi extends BaseApi {
     const useDevLocalEndpoint = isLocalDevAuditMode();
 
     if (useDevLocalEndpoint) {
-      return this.getLiveOverview();
+      const baseURL = getLocalDevBaseURL();
+      const endpoint = `${baseURL}/system/dev/live-audit/run`;
+      const response = await fetch(endpoint, {
+        method: "POST",
+      });
+
+      const payload = await response.json().catch(() => null);
+
+      if (!response.ok || !payload?.success) {
+        throw new Error(payload?.error || "Failed to refresh live integration audit overview");
+      }
+
+      return {
+        ...payload.data,
+        __debug: {
+          endpoint,
+          mode: "dev-live-refresh",
+        },
+      };
     }
 
     const token = this.getAuthToken();


### PR DESCRIPTION
## Summary
Enhances the internal integration audit dashboard in `Nutrihelp-web` so developers can inspect route-level flow details, richer classifications, contract validation results, and runtime data quality signals in one place. This update adds clickable route drill-down, frontend/API/AI layer health display, contract validation rendering, response sample quality display, and support for the new BE38 live audit payload.

## What files changed
- `src/routes/AdminAudit/AdminAuditDashboard.jsx`
- `src/routes/AdminAudit/AdminAuditDashboard.css`
- `src/services/adminAuditApi.js`

## Test
- Ran frontend build successfully:
  - `npm run build`
- Confirmed the dashboard remains available at:
  - `/admin/integration-audit`
- Verified the dashboard now supports:
  - route click-through detail view
  - richer route classifications
  - frontend/API/AI layer status display
  - backend contract validation rendering
  - runtime data quality rendering from sampled responses
  - local dev manual live refresh via the new backend refresh endpoint
- Build completed successfully with only existing repository warnings remaining:
  - CRA/Babel maintenance warning
  - `html2pdf.js` source map warning
  - existing autoprefixer warnings
