### PR TITLE
Fix route protection and persistent auth session lifecycle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -115,7 +115,7 @@ function RouteScrollToTop() {
 import WeeklyMealPlanPage from './routes/Meal/WeeklyMealPlanPage';
 
 function App() {
-  const { currentUser } = useContext(UserContext);
+  const { currentUser, authReady } = useContext(UserContext);
 
   useEffect(() => {
     initializeFontSize();
@@ -133,7 +133,7 @@ function App() {
         <Route
           path="/"
           element={
-            currentUser ? <Navigate to="/home" /> : <Navigate to="/login" />
+            !authReady ? null : currentUser ? <Navigate to="/home" /> : <Navigate to="/login" />
           }
         />
 
@@ -152,18 +152,95 @@ function App() {
 
         <Route path="/mfa" element={<MFAform />} />
 
-        <Route path="/home" element={<Home />} />
-        <Route path="/faq" element={<FAQ />} />
-        <Route path="/leaderboard" element={<Leaderboard />} />
-        <Route path="/community" element={<Community />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/community/post/:postId" element={<PostDetail />} />
+        <Route
+          path="/home"
+          element={
+            <AuthenticateRoute>
+              <Home />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/faq"
+          element={
+            <AuthenticateRoute>
+              <FAQ />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/leaderboard"
+          element={
+            <AuthenticateRoute>
+              <Leaderboard />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/community"
+          element={
+            <AuthenticateRoute>
+              <Community />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/chat"
+          element={
+            <AuthenticateRoute>
+              <ChatPage />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/community/post/:postId"
+          element={
+            <AuthenticateRoute>
+              <PostDetail />
+            </AuthenticateRoute>
+          }
+        />
 
-        <Route path="/survey" element={<ObesityPredictor />} />
-        <Route path="/survey/result" element={<Predictionresult />} />
-        <Route path="/roadmap" element={<FitnessRoadmap />} />
-        <Route path="/Scan" element={<Scan />} />
-        <Route path="/scan" element={<Scan />} />
+        <Route
+          path="/survey"
+          element={
+            <AuthenticateRoute>
+              <ObesityPredictor />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/survey/result"
+          element={
+            <AuthenticateRoute>
+              <Predictionresult />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/roadmap"
+          element={
+            <AuthenticateRoute>
+              <FitnessRoadmap />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/Scan"
+          element={
+            <AuthenticateRoute>
+              <Scan />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="/scan"
+          element={
+            <AuthenticateRoute>
+              <Scan />
+            </AuthenticateRoute>
+          }
+        />
         <Route caseSensitive path="/Meal/*" element={<CanonicalMealRedirect />} />
         <Route
           path="/dish/detail"
@@ -181,7 +258,14 @@ function App() {
             </AuthenticateRoute>
           }
         />
-        <Route path="/account" element={<Account />} />
+        <Route
+          path="/account"
+          element={
+            <AuthenticateRoute>
+              <Account />
+            </AuthenticateRoute>
+          }
+        />
         {/* PRIVATE ROUTES */}
         <Route
           path="/daily-plan-edit"
@@ -349,7 +433,14 @@ function App() {
           }
         />
 
-        <Route path="/weekly-plan" element={<WeeklyMealPlanPage />} />
+        <Route
+          path="/weekly-plan"
+          element={
+            <AuthenticateRoute>
+              <WeeklyMealPlanPage />
+            </AuthenticateRoute>
+          }
+        />
         
 
         <Route path="/auth/callback" element={<AuthCallback />} />
@@ -372,7 +463,14 @@ function App() {
           }
         />
 
-        <Route path="/symptomassessment" element={<SymptomAssessment />} />
+        <Route
+          path="/symptomassessment"
+          element={
+            <AuthenticateRoute>
+              <SymptomAssessment />
+            </AuthenticateRoute>
+          }
+        />
 
         <Route
           path="healthnews"
@@ -446,8 +544,22 @@ function App() {
           }
         />
 
-        <Route path="ScanBarcode" element={<ScanBarcode />} />
-        <Route path="scan" element={<Scan />}/>
+        <Route
+          path="ScanBarcode"
+          element={
+            <AuthenticateRoute>
+              <ScanBarcode />
+            </AuthenticateRoute>
+          }
+        />
+        <Route
+          path="scan"
+          element={
+            <AuthenticateRoute>
+              <Scan />
+            </AuthenticateRoute>
+          }
+        />
       </Routes>
     </Router>
   );

--- a/src/auth/SupabaseUserSync.jsx
+++ b/src/auth/SupabaseUserSync.jsx
@@ -1,32 +1,37 @@
-import { useEffect, useContext } from "react";
-import { supabase } from '../supabaseClient';
-import { UserContext } from "../context/user.context";
+import { useEffect } from "react";
+import { supabase } from "../supabaseClient";
+
+function hasBackendSession() {
+  const directToken =
+    localStorage.getItem("auth_token") ||
+    sessionStorage.getItem("auth_token") ||
+    localStorage.getItem("jwt_token") ||
+    sessionStorage.getItem("jwt_token");
+
+  if (directToken) return true;
+
+  const storedUser =
+    localStorage.getItem("user") ||
+    localStorage.getItem("user_session") ||
+    sessionStorage.getItem("user_session");
+
+  return Boolean(storedUser);
+}
 
 export default function SupabaseUserSync() {
-  const { setCurrentUser } = useContext(UserContext);
-
   useEffect(() => {
-
-    supabase.auth.getSession().then(({ data }) => {
-      const u = data.session?.user;
-      if (u) {
-        setCurrentUser({ email: u.email, id: u.id }, 0);
-      }
-    });
-
-
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      const u = session?.user;
-      if (u) {
-        setCurrentUser({ email: u.email, id: u.id }, 0);
-      } else {
-        setCurrentUser(null, 0);
+      if (session?.user) {
+        return;
+      }
+
+      if (!hasBackendSession()) {
+        localStorage.removeItem("sso_session");
       }
     });
-
 
     return () => sub.subscription.unsubscribe();
-  }, [setCurrentUser]);
+  }, []);
 
   return null;
 }

--- a/src/context/user.context.jsx
+++ b/src/context/user.context.jsx
@@ -1,132 +1,3 @@
-// import React from 'react';
-// import { createContext, useState } from 'react';
-
-// //The function to set the context for the logged in user
-// //This function will be called by the in-built react function, "userContext()"
-// // in order to set the current user
-// export const UserContext = createContext(
-//     {
-//         currentUser: null,
-//         setCurrentUser: () => null
-//     }
-// )
-
-// //Gives access to the values in the UserContext
-// export const UserProvider = ({ children }) => {
-//     //Set the current user
-//     const [currentUser, setCurrentUser] = useState(null)
-
-//     //Use destructuring to set the constant, "value"
-//     //to take the function, setCurrentUser, and the variable, currentUser
-//     const value = { currentUser, setCurrentUser }
-
-//     return (
-//         <UserContext.Provider value={value}>
-//             {children}
-//         </UserContext.Provider>
-//     )
-// }
-
-
-
-// import React, { createContext, useState, useEffect } from 'react';
-
-// // creating react context to configure logging in user
-// export const UserContext = createContext({
-//     currentUser: null,
-//     setCurrentUser: () => null,
-//     logOut: () => null,
-// });
-
-// export const UserProvider = ({ children }) => {
-//     const [currentUser, setCurrentUser] = useState(() => {
-//     //    get value of current user from localstorage
-//         const userFromStorage = localStorage.getItem('user');
-//         return userFromStorage ? JSON.parse(userFromStorage) : null;
-//     });
-
-//     // to add the user in local storage
-//     const setUser = (user) => {
-//         setCurrentUser(user);
-//         if (user) {
-//             localStorage.setItem('user', JSON.stringify(user)); 
-//         } else {
-//             localStorage.removeItem('user'); // remove storage data if there is no user
-//         }
-//     };
-
-//     const logOut = () => {
-//         localStorage.removeItem('user');
-//         setCurrentUser(null);
-//     };
-
-//     const value = { currentUser, setCurrentUser: setUser, logOut };
-
-//     return (
-//         <UserContext.Provider value={value}>
-//             {children}
-//         </UserContext.Provider>
-//     );
-// };
-
-// import React, { createContext, useState, useEffect } from 'react';
-
-// export const UserContext = createContext({
-//     currentUser: null,
-//     setCurrentUser: () => null,
-//     logOut: () => null,
-// });
-
-// export const UserProvider = ({ children }) => {
-//     const [currentUser, setCurrentUser] = useState(() => {
-//         // get value of current user from localstorage
-//         const storedUser = localStorage.getItem('user');
-//         const storedExpirationTime = localStorage.getItem('expirationTime');
-        
-//         if (storedUser && storedExpirationTime) {
-//             // Check if the expiration time is still valid
-//             const expirationTime = JSON.parse(storedExpirationTime);
-//             if (Date.now() > expirationTime) {
-//                 // If expired, clear the user data
-//                 localStorage.removeItem('user');
-//                 localStorage.removeItem('expirationTime');
-//                 return null;
-//             }
-//             return JSON.parse(storedUser);
-//         }
-//         return null;
-//     });
-
-//     const setUser = (user, expirationTimeInMillis) => {
-//         if (user) {
-//             // Set expiration time if the user is logged in
-//             setCurrentUser(user);
-//             const expirationTime = Date.now() + expirationTimeInMillis;
-//             localStorage.setItem('user', JSON.stringify(user));
-//             localStorage.setItem('expirationTime', JSON.stringify(expirationTime));
-//         } else {
-//             // Clear user and expiration time if logged out
-//             localStorage.removeItem('user');
-//             localStorage.removeItem('expirationTime');
-//         }
-//     };
-
-//     const logOut = () => {
-//         localStorage.removeItem('user');
-//         localStorage.removeItem('userExpireTime');
-//         setCurrentUser(null);
-//     };
-
-//     const value = { currentUser, setCurrentUser: setUser, logOut };
-
-//     return (
-//         <UserContext.Provider value={value}>
-//             {children}
-//         </UserContext.Provider>
-//     );
-// };
-
-
 import React, {
   createContext,
   useCallback,
@@ -136,148 +7,550 @@ import React, {
   useState,
 } from "react";
 
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8081";
+const DEFAULT_PERSIST_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const REFRESH_BUFFER_MS = 60 * 1000;
+
 export const UserContext = createContext({
   currentUser: null,
-  // same signature you call in Login.jsx: setCurrentUser(user, expirationTimeInMillis)
-  setCurrentUser: (_user, _ttlMs = 0) => {},
-  logOut: () => {},
+  authReady: false,
+  setCurrentUser: () => {},
+  logOut: async () => {},
+  refreshSession: async () => null,
 });
 
 const KEYS = {
-  localUser: "user",                 // persistent (keep me logged in)
-  localExpiry: "expirationTime",     // ms epoch
-  sessionUser: "user_session",       // non-persistent (until tab/browser close)
+  localUser: "user",
+  localExpiry: "expirationTime",
+  sessionUser: "user_session",
+  authToken: "auth_token",
+  refreshToken: "refresh_token",
+  jwtToken: "jwt_token",
+  token: "token",
+  ssoSession: "sso_session",
 };
 
-// helpers
-function readLocal() {
+function safeParse(value) {
+  if (!value) return null;
   try {
-    const u = localStorage.getItem(KEYS.localUser);
-    const exp = localStorage.getItem(KEYS.localExpiry);
-    if (!u || !exp) return null;
-    const expiresAt = JSON.parse(exp);
-    if (typeof expiresAt === "number" && expiresAt > 0 && Date.now() > expiresAt) {
-      // expired -> clear
-      localStorage.removeItem(KEYS.localUser);
-      localStorage.removeItem(KEYS.localExpiry);
-      return null;
-    }
-    return JSON.parse(u);
-  } catch {
+    return JSON.parse(value);
+  } catch (_error) {
     return null;
   }
 }
 
-function readSession() {
-  try {
-    const u = sessionStorage.getItem(KEYS.sessionUser);
-    return u ? JSON.parse(u) : null;
-  } catch {
-    return null;
-  }
+function toPositiveNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
-function writeLocal(user, expiresAt) {
+function readRawUser(storage, key) {
+  return safeParse(storage.getItem(key));
+}
+
+function readStoredUser() {
+  const localUser = readRawUser(localStorage, KEYS.localUser);
+  const sessionUser =
+    readRawUser(sessionStorage, KEYS.sessionUser) ||
+    readRawUser(localStorage, KEYS.sessionUser);
+
+  const candidate = localUser || sessionUser;
+  if (!candidate || typeof candidate !== "object") return null;
+
+  const accessToken =
+    candidate.accessToken ||
+    candidate.token ||
+    localStorage.getItem(KEYS.authToken) ||
+    sessionStorage.getItem(KEYS.authToken) ||
+    localStorage.getItem(KEYS.jwtToken) ||
+    sessionStorage.getItem(KEYS.jwtToken) ||
+    localStorage.getItem(KEYS.token) ||
+    sessionStorage.getItem(KEYS.token) ||
+    "";
+
+  const refreshToken =
+    candidate.refreshToken ||
+    localStorage.getItem(KEYS.refreshToken) ||
+    sessionStorage.getItem(KEYS.refreshToken) ||
+    "";
+
+  const sessionExpiresAt =
+    toPositiveNumber(candidate.sessionExpiresAt) ||
+    toPositiveNumber(localStorage.getItem(KEYS.localExpiry));
+
+  if (localUser && sessionExpiresAt && Date.now() > sessionExpiresAt) {
+    return null;
+  }
+
+  return {
+    ...candidate,
+    token: accessToken,
+    accessToken,
+    refreshToken,
+    tokenType: candidate.tokenType || "Bearer",
+    expiresIn: toPositiveNumber(candidate.expiresIn),
+    accessTokenExpiresAt: toPositiveNumber(candidate.accessTokenExpiresAt),
+    sessionExpiresAt,
+    rememberMe: Boolean(candidate.rememberMe || localUser),
+  };
+}
+
+function clearLocalSession() {
+  localStorage.removeItem(KEYS.localUser);
+  localStorage.removeItem(KEYS.localExpiry);
+  localStorage.removeItem(KEYS.authToken);
+  localStorage.removeItem(KEYS.refreshToken);
+  localStorage.removeItem(KEYS.jwtToken);
+  localStorage.removeItem(KEYS.token);
+}
+
+function clearSessionSession() {
+  sessionStorage.removeItem(KEYS.sessionUser);
+  sessionStorage.removeItem(KEYS.authToken);
+  sessionStorage.removeItem(KEYS.refreshToken);
+  sessionStorage.removeItem(KEYS.jwtToken);
+  sessionStorage.removeItem(KEYS.token);
+  localStorage.removeItem(KEYS.sessionUser);
+}
+
+function clearAllSessionStorage() {
+  clearLocalSession();
+  clearSessionSession();
+  localStorage.removeItem(KEYS.ssoSession);
+  sessionStorage.removeItem(KEYS.ssoSession);
+}
+
+function writePersistentSession(user) {
   localStorage.setItem(KEYS.localUser, JSON.stringify(user));
-  localStorage.setItem(KEYS.localExpiry, JSON.stringify(expiresAt || 0));
+  localStorage.setItem(KEYS.localExpiry, String(user.sessionExpiresAt || 0));
+  localStorage.setItem(KEYS.sessionUser, JSON.stringify(user));
+  localStorage.setItem(KEYS.authToken, user.token || "");
+  if (user.refreshToken) {
+    localStorage.setItem(KEYS.refreshToken, user.refreshToken);
+  } else {
+    localStorage.removeItem(KEYS.refreshToken);
+  }
+
   sessionStorage.removeItem(KEYS.sessionUser);
+  sessionStorage.removeItem(KEYS.authToken);
+  sessionStorage.removeItem(KEYS.refreshToken);
 }
 
-function writeSession(user) {
+function writeSessionOnly(user) {
   sessionStorage.setItem(KEYS.sessionUser, JSON.stringify(user));
+  sessionStorage.setItem(KEYS.authToken, user.token || "");
+  if (user.refreshToken) {
+    sessionStorage.setItem(KEYS.refreshToken, user.refreshToken);
+  } else {
+    sessionStorage.removeItem(KEYS.refreshToken);
+  }
+
   localStorage.removeItem(KEYS.localUser);
   localStorage.removeItem(KEYS.localExpiry);
+  localStorage.removeItem(KEYS.authToken);
+  localStorage.removeItem(KEYS.refreshToken);
+  localStorage.removeItem(KEYS.jwtToken);
+  localStorage.removeItem(KEYS.token);
+  localStorage.removeItem(KEYS.sessionUser);
 }
 
-function clearAll() {
-  localStorage.removeItem(KEYS.localUser);
-  localStorage.removeItem(KEYS.localExpiry);
-  sessionStorage.removeItem(KEYS.sessionUser);
+function normalizeSessionOptions(input, previousUser) {
+  if (typeof input === "number") {
+    return {
+      persist: input > 0,
+      sessionTtlMs: input > 0 ? input : 0,
+    };
+  }
+
+  if (!input || typeof input !== "object") {
+    return {
+      persist: Boolean(previousUser?.rememberMe),
+      sessionTtlMs:
+        previousUser?.rememberMe && previousUser?.sessionExpiresAt
+          ? Math.max(previousUser.sessionExpiresAt - Date.now(), 0)
+          : 0,
+    };
+  }
+
+  return {
+    persist:
+      typeof input.persist === "boolean"
+        ? input.persist
+        : Boolean(input.rememberMe ?? previousUser?.rememberMe),
+    sessionTtlMs: toPositiveNumber(input.sessionTtlMs || input.ttlMs),
+    sessionExpiresAt: toPositiveNumber(input.sessionExpiresAt),
+    accessToken: input.accessToken || input.token || "",
+    refreshToken: input.refreshToken || "",
+    tokenType: input.tokenType || "",
+    expiresIn: toPositiveNumber(input.expiresIn),
+    accessTokenExpiresAt: toPositiveNumber(input.accessTokenExpiresAt),
+  };
+}
+
+function buildSessionUser(nextUser, options, previousUser) {
+  const resolvedOptions = normalizeSessionOptions(options, previousUser);
+  const merged = {
+    ...(previousUser || {}),
+    ...(nextUser || {}),
+  };
+
+  const accessToken =
+    resolvedOptions.accessToken ||
+    merged.accessToken ||
+    merged.token ||
+    previousUser?.accessToken ||
+    previousUser?.token ||
+    "";
+
+  const refreshToken =
+    resolvedOptions.refreshToken ||
+    merged.refreshToken ||
+    previousUser?.refreshToken ||
+    "";
+
+  const tokenType =
+    resolvedOptions.tokenType ||
+    merged.tokenType ||
+    previousUser?.tokenType ||
+    "Bearer";
+
+  const expiresIn =
+    resolvedOptions.expiresIn ||
+    toPositiveNumber(merged.expiresIn) ||
+    toPositiveNumber(previousUser?.expiresIn);
+
+  const accessTokenExpiresAt =
+    resolvedOptions.accessTokenExpiresAt ||
+    toPositiveNumber(merged.accessTokenExpiresAt) ||
+    (expiresIn > 0 ? Date.now() + expiresIn * 1000 : 0) ||
+    toPositiveNumber(previousUser?.accessTokenExpiresAt);
+
+  const persist = resolvedOptions.persist;
+  const sessionTtlMs =
+    resolvedOptions.sessionTtlMs ||
+    (persist ? DEFAULT_PERSIST_TTL_MS : 0);
+
+  const sessionExpiresAt = persist
+    ? resolvedOptions.sessionExpiresAt || Date.now() + sessionTtlMs
+    : 0;
+
+  return {
+    ...merged,
+    token: accessToken,
+    accessToken,
+    refreshToken,
+    tokenType,
+    expiresIn,
+    accessTokenExpiresAt,
+    sessionExpiresAt,
+    rememberMe: persist,
+  };
+}
+
+async function parseJsonSafe(response) {
+  try {
+    return await response.json();
+  } catch (_error) {
+    return {};
+  }
 }
 
 export const UserProvider = ({ children }) => {
-  // Rehydrate on first render: prefer persistent, else session
-  const [currentUser, setCurrentUserState] = useState(() => {
-    return readLocal() ?? readSession() ?? null;
-  });
-
+  const [currentUser, setCurrentUserState] = useState(() => readStoredUser());
+  const [authReady, setAuthReady] = useState(false);
+  const currentUserRef = useRef(readStoredUser());
   const logoutTimerRef = useRef(null);
-  const scheduleLogout = useCallback((expiresAt) => {
-    if (logoutTimerRef.current) clearTimeout(logoutTimerRef.current);
-    if (typeof expiresAt === "number" && expiresAt > 0) {
-      const delay = Math.max(0, expiresAt - Date.now());
-      logoutTimerRef.current = setTimeout(() => {
-        clearAll();
-        setCurrentUserState(null);
-      }, delay);
+  const refreshTimerRef = useRef(null);
+  const refreshPromiseRef = useRef(null);
+  const refreshSessionRef = useRef(async () => null);
+
+  const clearTimers = useCallback(() => {
+    if (logoutTimerRef.current) {
+      clearTimeout(logoutTimerRef.current);
+      logoutTimerRef.current = null;
+    }
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
     }
   }, []);
 
-  // On mount, if local user exists with expiry, schedule auto-logout
-  useEffect(() => {
-    const exp = localStorage.getItem(KEYS.localExpiry);
-    const expiresAt = exp ? JSON.parse(exp) : 0;
-    scheduleLogout(expiresAt);
-
-    // keep multiple tabs in sync
-    const onStorage = (e) => {
-      if (!e.key) return;
-
-      // If persistent keys change
-      if (e.key === KEYS.localUser || e.key === KEYS.localExpiry) {
-        const u = readLocal();
-        setCurrentUserState(u);
-        const exp2 = localStorage.getItem(KEYS.localExpiry);
-        scheduleLogout(exp2 ? JSON.parse(exp2) : 0);
-      }
-
-      // If session key changes
-      if (e.key === KEYS.sessionUser) {
-        const u = readSession();
-        setCurrentUserState(u);
-        scheduleLogout(0);
-      }
-    };
-    window.addEventListener("storage", onStorage);
-    return () => {
-      window.removeEventListener("storage", onStorage);
-      if (logoutTimerRef.current) clearTimeout(logoutTimerRef.current);
-    };
-  }, [scheduleLogout]);
-
-  /**
-   * setCurrentUser(user, ttlMs)
-   * - ttlMs > 0  => persist in localStorage for ttlMs (keep me logged in)
-   * - ttlMs === 0 => store in sessionStorage (dies on tab/browser close)
-   */
-  const setCurrentUser = useCallback((user, ttlMs = 0) => {
-    if (user) {
+  const applyUserState = useCallback(
+    (user) => {
+      currentUserRef.current = user;
       setCurrentUserState(user);
-      if (ttlMs > 0) {
-        const expiresAt = Date.now() + ttlMs;
-        writeLocal(user, expiresAt);
-        scheduleLogout(expiresAt);
-      } else {
-        writeSession(user);
-        scheduleLogout(0);
-      }
-    } else {
-      // explicit clear
-      clearAll();
-      setCurrentUserState(null);
-      scheduleLogout(0);
-    }
-  }, [scheduleLogout]);
 
-  const logOut = useCallback(() => {
-    clearAll();
-    setCurrentUserState(null);
-    scheduleLogout(0);
-  }, [scheduleLogout]);
+      clearTimers();
+
+      if (!user) {
+        clearAllSessionStorage();
+        return;
+      }
+
+      if (user.rememberMe) {
+        writePersistentSession(user);
+      } else {
+        writeSessionOnly(user);
+      }
+
+      if (user.rememberMe && user.sessionExpiresAt > 0) {
+        const delay = Math.max(0, user.sessionExpiresAt - Date.now());
+        logoutTimerRef.current = setTimeout(() => {
+          clearAllSessionStorage();
+          currentUserRef.current = null;
+          setCurrentUserState(null);
+        }, delay);
+      }
+    },
+    [clearTimers]
+  );
+
+  const scheduleRefresh = useCallback(
+    (user) => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+
+      if (!user?.refreshToken || !user?.accessTokenExpiresAt) {
+        return;
+      }
+
+      const refreshAt = Math.max(
+        5000,
+        user.accessTokenExpiresAt - Date.now() - REFRESH_BUFFER_MS
+      );
+
+      refreshTimerRef.current = setTimeout(() => {
+        refreshSessionRef.current?.().catch(() => {});
+      }, refreshAt);
+    },
+    []
+  );
+
+  const refreshSession = useCallback(async () => {
+    const storedUser = currentUserRef.current || readStoredUser();
+    if (!storedUser?.refreshToken) {
+      return null;
+    }
+
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    refreshPromiseRef.current = (async () => {
+      const response = await fetch(`${API_BASE_URL}/api/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: storedUser.refreshToken }),
+      });
+
+      const payload = await parseJsonSafe(response);
+      const session = payload?.data?.session || payload?.session || {};
+
+      if (!response.ok || !session?.accessToken) {
+        throw new Error(payload?.error?.message || payload?.error || "Session refresh failed");
+      }
+
+      const refreshedUser = buildSessionUser(
+        storedUser,
+        {
+          persist: storedUser.rememberMe,
+          sessionTtlMs: storedUser.rememberMe ? DEFAULT_PERSIST_TTL_MS : 0,
+          accessToken: session.accessToken,
+          refreshToken: session.refreshToken || storedUser.refreshToken,
+          tokenType: session.tokenType,
+          expiresIn: session.expiresIn,
+        },
+        storedUser
+      );
+
+      applyUserState(refreshedUser);
+      scheduleRefresh(refreshedUser);
+      return refreshedUser;
+    })()
+      .catch((error) => {
+        applyUserState(null);
+        throw error;
+      })
+      .finally(() => {
+        refreshPromiseRef.current = null;
+      });
+
+    return refreshPromiseRef.current;
+  }, [applyUserState, scheduleRefresh]);
+
+  useEffect(() => {
+    refreshSessionRef.current = refreshSession;
+  }, [refreshSession]);
+
+  useEffect(() => {
+    if (currentUserRef.current) {
+      scheduleRefresh(currentUserRef.current);
+    }
+  }, [scheduleRefresh]);
+
+  const logOut = useCallback(async () => {
+    const storedUser = currentUserRef.current || readStoredUser();
+
+    if (storedUser?.refreshToken) {
+      try {
+        await fetch(`${API_BASE_URL}/api/auth/logout`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ refreshToken: storedUser.refreshToken }),
+        });
+      } catch (_error) {
+        // Best-effort logout only.
+      }
+    }
+
+    applyUserState(null);
+  }, [applyUserState]);
+
+  const verifyStoredSession = useCallback(async () => {
+    const storedUser = readStoredUser();
+
+    if (!storedUser?.token) {
+      applyUserState(null);
+      setAuthReady(true);
+      return null;
+    }
+
+    const tryProfile = async (accessToken) => {
+      const response = await fetch(`${API_BASE_URL}/api/auth/profile`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const payload = await parseJsonSafe(response);
+      return { response, payload };
+    };
+
+    try {
+      let activeUser = storedUser;
+      let profileResult = await tryProfile(storedUser.token);
+
+      if (profileResult.response.status === 401 && storedUser.refreshToken) {
+        activeUser = await refreshSession();
+        if (activeUser?.token) {
+          profileResult = await tryProfile(activeUser.token);
+        }
+      }
+
+      if (!profileResult.response.ok) {
+        applyUserState(null);
+        setAuthReady(true);
+        return null;
+      }
+
+      const verifiedProfile = profileResult.payload?.data?.user || activeUser;
+      const verifiedUser = buildSessionUser(verifiedProfile, activeUser, activeUser);
+      applyUserState(verifiedUser);
+      setAuthReady(true);
+      return verifiedUser;
+    } catch (_error) {
+      applyUserState(null);
+      setAuthReady(true);
+      return null;
+    }
+  }, [applyUserState, refreshSession, scheduleRefresh]);
+
+  useEffect(() => {
+    verifyStoredSession();
+
+    const onVisibilityRefresh = () => {
+      if (document.visibilityState === "visible") {
+        const storedUser = currentUserRef.current || readStoredUser();
+        if (!storedUser?.token) return;
+
+        if (
+          storedUser.refreshToken &&
+          storedUser.accessTokenExpiresAt &&
+          storedUser.accessTokenExpiresAt - Date.now() <= REFRESH_BUFFER_MS
+        ) {
+          refreshSession().catch(() => {});
+        }
+      }
+    };
+
+    const onWindowFocus = () => {
+      const storedUser = currentUserRef.current || readStoredUser();
+      if (!storedUser?.token) return;
+
+      if (
+        storedUser.refreshToken &&
+        storedUser.accessTokenExpiresAt &&
+        storedUser.accessTokenExpiresAt - Date.now() <= REFRESH_BUFFER_MS
+      ) {
+        refreshSession().catch(() => {});
+      }
+    };
+
+    const onStorage = () => {
+      const storedUser = readStoredUser();
+      currentUserRef.current = storedUser;
+      setCurrentUserState(storedUser);
+      if (storedUser) {
+        clearTimers();
+        if (storedUser.rememberMe && storedUser.sessionExpiresAt > 0) {
+          const delay = Math.max(0, storedUser.sessionExpiresAt - Date.now());
+          logoutTimerRef.current = setTimeout(() => {
+            clearAllSessionStorage();
+            currentUserRef.current = null;
+            setCurrentUserState(null);
+          }, delay);
+        }
+        scheduleRefresh(storedUser);
+      } else {
+        clearTimers();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityRefresh);
+    window.addEventListener("focus", onWindowFocus);
+    window.addEventListener("storage", onStorage);
+
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityRefresh);
+      window.removeEventListener("focus", onWindowFocus);
+      window.removeEventListener("storage", onStorage);
+      clearTimers();
+    };
+  }, [clearTimers, refreshSession, scheduleRefresh, verifyStoredSession]);
+
+  const setCurrentUser = useCallback(
+    (userOrUpdater, options = 0) => {
+      const previousUser = currentUserRef.current;
+      const nextUser =
+        typeof userOrUpdater === "function"
+          ? userOrUpdater(previousUser)
+          : userOrUpdater;
+
+      if (!nextUser) {
+        applyUserState(null);
+        setAuthReady(true);
+        return;
+      }
+
+      const sessionUser = buildSessionUser(nextUser, options, previousUser);
+      applyUserState(sessionUser);
+      scheduleRefresh(sessionUser);
+      setAuthReady(true);
+    },
+    [applyUserState, scheduleRefresh]
+  );
 
   const value = useMemo(
-    () => ({ currentUser, setCurrentUser, logOut }),
-    [currentUser, setCurrentUser, logOut]
+    () => ({
+      currentUser,
+      authReady,
+      setCurrentUser,
+      logOut,
+      refreshSession,
+    }),
+    [authReady, currentUser, logOut, refreshSession, setCurrentUser]
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -70,6 +70,18 @@ export default function AuthCallback() {
             exchangeData?.token ||
             exchangeData?.session?.accessToken ||
             ""
+          const backendRefreshToken =
+            exchangeData?.refreshToken ||
+            exchangeData?.session?.refreshToken ||
+            ""
+          const backendExpiresIn =
+            exchangeData?.expiresIn ||
+            exchangeData?.session?.expiresIn ||
+            0
+          const backendTokenType =
+            exchangeData?.tokenType ||
+            exchangeData?.session?.tokenType ||
+            "Bearer"
           const backendUser = exchangeData?.user || null
 
           if (!exchangeRes.ok || !backendToken || !backendUser?.id) {
@@ -102,10 +114,14 @@ export default function AuthCallback() {
             supabaseAccessToken,
           }
 
-          localStorage.setItem("auth_token", backendToken)
           localStorage.setItem("sso_session", "google")
-          localStorage.setItem("user_session", JSON.stringify(sessionUser))
-          setCurrentUser(sessionUser, 60 * 60 * 1000)
+          setCurrentUser(sessionUser, {
+            persist: true,
+            accessToken: backendToken,
+            refreshToken: backendRefreshToken,
+            expiresIn: backendExpiresIn,
+            tokenType: backendTokenType,
+          })
 
           navigate(next, { replace: true })
           return

--- a/src/routes/AuthenticateRoute/AuthenticateRoute.js
+++ b/src/routes/AuthenticateRoute/AuthenticateRoute.js
@@ -1,22 +1,13 @@
-import React, { useContext, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
-import { UserContext } from '../../context/user.context';
+import React, { useContext } from "react";
+import { Navigate } from "react-router-dom";
+import { UserContext } from "../../context/user.context";
 
 const AuthenticateRoute = ({ children }) => {
-  const { currentUser, setCurrentUser } = useContext(UserContext);
+  const { currentUser, authReady } = useContext(UserContext);
 
-  useEffect(() => {
-    const storedUser = localStorage.getItem('user');
-    if (storedUser) {
-      const user = JSON.parse(storedUser);
-      const expirationTime = user.expirationTime;
-
-      if (expirationTime && Date.now() > expirationTime) {
-        localStorage.removeItem('user');
-        setCurrentUser(null);
-      }
-    }
-  }, [setCurrentUser]);
+  if (!authReady) {
+    return null;
+  }
 
   return currentUser ? children : <Navigate to="/login" replace />;
 };

--- a/src/routes/AuthenticateRoute/InternalAdminRoute.jsx
+++ b/src/routes/AuthenticateRoute/InternalAdminRoute.jsx
@@ -11,10 +11,14 @@ function allowLocalDevAccess() {
 }
 
 const InternalAdminRoute = ({ children }) => {
-  const { currentUser } = useContext(UserContext);
+  const { currentUser, authReady } = useContext(UserContext);
 
   if (allowLocalDevAccess()) {
     return children;
+  }
+
+  if (!authReady) {
+    return null;
   }
 
   if (!currentUser) {

--- a/src/routes/Login/Login.jsx
+++ b/src/routes/Login/Login.jsx
@@ -10,47 +10,8 @@ import { toast } from "react-toastify"
 import "react-toastify/dist/ReactToastify.css"
 import { UserContext } from "../../context/user.context"
 import { useDarkMode } from "../DarkModeToggle/DarkModeContext"
-import { supabase } from "../../supabaseClient"
 import { useNavigate, useLocation } from "react-router-dom"
 import { API_BASE_URL } from "../../utils/authApi"
-
-function startInactivityWatcher({ enabled, seconds = 30, onTimeout }) {
-  if (window.__idleInterval) {
-    clearInterval(window.__idleInterval)
-    window.__idleInterval = null
-  }
-
-  const EVENTS = ["mousemove", "keydown", "click", "scroll", "touchstart"]
-  const KEY_LAST = "__idle:lastActivity"
-
-  const removeAll = (resetFn) =>
-    EVENTS.forEach((e) => window.removeEventListener(e, resetFn, { passive: true }))
-
-  if (!enabled) {
-    localStorage.removeItem(KEY_LAST)
-    return
-  }
-
-  const resetActivity = () => {
-    localStorage.setItem(KEY_LAST, String(Date.now()))
-  }
-
-  resetActivity()
-  EVENTS.forEach((e) => window.addEventListener(e, resetActivity, { passive: true }))
-
-  window.__idleInterval = setInterval(() => {
-    const last = parseInt(localStorage.getItem(KEY_LAST) || "0", 10)
-    if (!last) return
-    const idleMs = Date.now() - last
-    if (idleMs >= seconds * 1000) {
-      clearInterval(window.__idleInterval)
-      window.__idleInterval = null
-      removeAll(resetActivity)
-      localStorage.removeItem(KEY_LAST)
-      onTimeout?.()
-    }
-  }, 1000)
-}
 
 export default function Login() {
   // Existing UI state (unchanged)
@@ -119,7 +80,13 @@ export default function Login() {
       // Handle MFA required (202 status) - redirect to MFA page
       if (res.status === 202) {
         toast.info(payload?.message || data.message || "MFA token sent to your email")
-        navigate("/mfa", { state: { email: email.trim().toLowerCase(), password } })
+        navigate("/mfa", {
+          state: {
+            email: email.trim().toLowerCase(),
+            password,
+            rememberMe,
+          },
+        })
         return
       }
 
@@ -129,38 +96,41 @@ export default function Login() {
       }
 
       const user = payload?.user || data.user
-      const token = payload?.token || data.token
+      const accessToken =
+        payload?.session?.accessToken || payload?.accessToken || payload?.token || data.token
+      const refreshToken =
+        payload?.session?.refreshToken || payload?.refreshToken || data.refreshToken || ""
+      const expiresIn =
+        payload?.session?.expiresIn || payload?.expiresIn || data.expiresIn || 0
+      const tokenType =
+        payload?.session?.tokenType || payload?.tokenType || data.tokenType || "Bearer"
 
-      // ✅ Save session with JWT token
+      if (!user || !accessToken) {
+        toast.error("Login session is incomplete. Please try again.")
+        return
+      }
+
       const userSession = {
         id: user.user_id,
+        user_id: user.user_id,
         email: user.email,
         name: user.name,
-        token: token,
+        role: user.role || user.user_roles?.role_name || "user",
+        token: accessToken,
         provider: "email",
       }
 
-      localStorage.setItem("user_session", JSON.stringify(userSession))
-      localStorage.setItem("auth_token", token)
       localStorage.removeItem("sso_session")
 
-      // ✅ Set global context (if used)
       if (typeof setCurrentUser === "function") {
-        setCurrentUser(userSession, rememberMe ? 60 * 60 * 1000 : 0)
+        setCurrentUser(userSession, {
+          persist: rememberMe,
+          accessToken,
+          refreshToken,
+          expiresIn,
+          tokenType,
+        })
       }
-
-    // ✅ Optional inactivity logout
-    startInactivityWatcher({
-      enabled: !rememberMe,
-      seconds: 30,
-      onTimeout: async () => {
-        await supabase.auth.signOut()
-        localStorage.removeItem("user_session")
-        setCurrentUser?.(null)
-        toast.info("You were signed out due to inactivity.")
-        navigate("/login")
-      },
-    })
 
     toast.success("Welcome back!")
     navigate("/home")

--- a/src/routes/MFA/MFAform.jsx
+++ b/src/routes/MFA/MFAform.jsx
@@ -20,7 +20,7 @@ export default function MFAform() {
   const unwrapApiData = (payload) => (payload && typeof payload === "object" && "data" in payload ? payload.data : payload)
 
   // prefer explicit email/password passed from previous route, otherwise use user.email (if available)
-  const { email: locEmail, password: locPassword } = location.state || {}
+  const { email: locEmail, password: locPassword, rememberMe = false } = location.state || {}
   const email = locEmail || currentUser?.email || ""
   const password = locPassword || ""
 
@@ -105,26 +105,38 @@ export default function MFAform() {
 
       if (resp.ok) {
         const user = payload?.user || data.user
-        const token = payload?.token || data.token
+        const accessToken =
+          payload?.session?.accessToken || payload?.accessToken || payload?.token || data.token
+        const refreshToken =
+          payload?.session?.refreshToken || payload?.refreshToken || data.refreshToken || ""
+        const expiresIn =
+          payload?.session?.expiresIn || payload?.expiresIn || data.expiresIn || 0
+        const tokenType =
+          payload?.session?.tokenType || payload?.tokenType || data.tokenType || "Bearer"
 
-        if (!user || !token) {
+        if (!user || !accessToken) {
           setError("Login session is incomplete. Please try signing in again.")
           return
         }
 
         const userSession = {
           id: user.user_id,
+          user_id: user.user_id,
           email: user.email,
           name: user.name,
-          token,
+          role: user.role || user.user_roles?.role_name || "user",
+          token: accessToken,
           provider: "email_mfa",
         }
 
-        localStorage.setItem("user_session", JSON.stringify(userSession))
-        localStorage.setItem("auth_token", token)
-
         if (typeof setCurrentUser === "function") {
-          setCurrentUser(userSession)
+          setCurrentUser(userSession, {
+            persist: rememberMe,
+            accessToken,
+            refreshToken,
+            expiresIn,
+            tokenType,
+          })
         }
 
         navigate("/home")


### PR DESCRIPTION
## Summary
Strengthens frontend authentication flow in `Nutrihelp-web` by fixing protected-route access and making login sessions persist correctly through the backend token lifecycle. This update closes the gap where users could still access internal app routes from stale browser state, and it replaces short-lived frontend-only session behavior with verified session restore plus refresh-token-based continuity.

## What files changed
- `src/App.js`
- `src/auth/SupabaseUserSync.jsx`
- `src/context/user.context.jsx`
- `src/pages/AuthCallback.jsx`
- `src/routes/AuthenticateRoute/AuthenticateRoute.js`
- `src/routes/AuthenticateRoute/InternalAdminRoute.jsx`
- `src/routes/Login/Login.jsx`
- `src/routes/MFA/MFAform.jsx`

## Testing
- Ran frontend production build successfully:
  - `npm run build`
- Restarted the local web app and verified it compiles successfully after the auth/session changes
- Confirmed protected routes are now wrapped by `AuthenticateRoute` instead of remaining publicly reachable through direct URL changes
- Confirmed session restore now depends on backend verification via `/api/auth/profile`
- Confirmed the frontend auth flow now supports refresh-token-based session continuity instead of relying only on short-lived access token timing
- Verified login, MFA, and Google auth callback flows now pass session token data into the shared auth lifecycle
- Existing repository warnings remained during build:
  - CRA/Babel maintenance warning
  - `html2pdf.js` source map warning
  - existing autoprefixer warnings