### PR TITLE
Fix missing useEffect wrapper in DailyPlanEdit (syntax error)

### DIFF
--- a/src/routes/DailyPlan/DailyPlanEdit.jsx
+++ b/src/routes/DailyPlan/DailyPlanEdit.jsx
@@ -392,6 +392,8 @@ export default function DailyPlanEdit() {
       .finally(() => { if (mounted) setAiLoading(false); });
     return () => { mounted = false; };
   }, [navigate]);
+
+  useEffect(() => {
     const queue = readImageEnrichmentQueue();
     const jobs = [];
 


### PR DESCRIPTION
## Summary
- `DailyPlanEdit.jsx`: the image enrichment `useEffect` was missing its `useEffect(() => {` opening, leaving ~60 lines of hook body as floating module-level code
- This caused a compile-time `SyntaxError: Unexpected token` at the dependency array closing brace (`}, [selectionsByDate])`)
- Fix: wrap the orphaned block in `useEffect(() => {` so it correctly pairs with its existing closing

## Test plan
- [ ] `npm start` compiles without errors
- [ ] Daily Plan Edit page loads and image enrichment runs as before