### PR TITLE
Fix Google auth callback response parsing

### DIFF
--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -65,15 +65,20 @@ export default function AuthCallback() {
           })
 
           const exchangeData = await parseJsonSafe(exchangeRes)
+          const exchangePayload = exchangeData?.data || exchangeData
           const backendToken =
-            exchangeData?.accessToken ||
-            exchangeData?.token ||
-            exchangeData?.session?.accessToken ||
+            exchangePayload?.accessToken ||
+            exchangePayload?.token ||
+            exchangePayload?.session?.accessToken ||
             ""
-          const backendUser = exchangeData?.user || null
+          const backendUser = exchangePayload?.user || null
 
           if (!exchangeRes.ok || !backendToken || !backendUser?.id) {
-            throw new Error(exchangeData?.error || "Unable to complete Google sign-in.")
+            throw new Error(
+              exchangeData?.error?.message ||
+              exchangeData?.error ||
+              "Unable to complete Google sign-in."
+            )
           }
 
           const sessionUser = {


### PR DESCRIPTION
## Summary
Fix Google OAuth callback handling by reading the backend exchange response from the canonical `data` envelope, while keeping compatibility with the previous flat response shape.

## Testing
- Ran `npm test -- --runTestsByPath src/utils/ttsRouteUtils.test.js`
- Verified local Google auth exchange returns `200` from the backend after the callback flow