### PR TITLE
Login forgot password fixes

### DIFF
--- a/src/routes/ForgotPassword/ForgotPasswordReset.jsx
+++ b/src/routes/ForgotPassword/ForgotPasswordReset.jsx
@@ -5,6 +5,9 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { Eye, EyeOff } from "lucide-react";
 import { API_BASE_URL, parseJsonSafe } from "../../utils/authApi";
 
+const FORGOT_PASSWORD_EMAIL_KEY = "nutrihelp.forgotPassword.email";
+const FORGOT_PASSWORD_RESET_TOKEN_KEY = "nutrihelp.forgotPassword.resetToken";
+
 /**
  * ForgotPasswordReset.jsx
  * - Expects location.state.email and resetToken
@@ -19,8 +22,12 @@ export default function ForgotPasswordReset() {
   const providedResetToken =
     (location && location.state && location.state.resetToken) || "";
 
-  const [email] = useState(providedEmail);
-  const [resetToken] = useState(providedResetToken);
+  const [email] = useState(
+    providedEmail || sessionStorage.getItem(FORGOT_PASSWORD_EMAIL_KEY) || ""
+  );
+  const [resetToken] = useState(
+    providedResetToken || sessionStorage.getItem(FORGOT_PASSWORD_RESET_TOKEN_KEY) || ""
+  );
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -71,6 +78,8 @@ export default function ForgotPasswordReset() {
         throw new Error(d.error || d.message || `Reset failed (HTTP ${res.status})`);
       }
       setServerMsg("Password updated! Redirecting to login...");
+      sessionStorage.removeItem(FORGOT_PASSWORD_EMAIL_KEY);
+      sessionStorage.removeItem(FORGOT_PASSWORD_RESET_TOKEN_KEY);
       setTimeout(() => navigate("/login"), 1200);
     } catch (err) {
       setServerMsg(err.message || "Reset failed");
@@ -83,6 +92,15 @@ export default function ForgotPasswordReset() {
     const el = document.querySelector(".fpr-card input");
     if (el) el.setAttribute("autofocus", "true");
   }, []);
+
+  useEffect(() => {
+    if (email) {
+      sessionStorage.setItem(FORGOT_PASSWORD_EMAIL_KEY, email);
+    }
+    if (resetToken) {
+      sessionStorage.setItem(FORGOT_PASSWORD_RESET_TOKEN_KEY, resetToken);
+    }
+  }, [email, resetToken]);
 
   return (
     <div>
@@ -145,7 +163,12 @@ export default function ForgotPasswordReset() {
 
       <div className="fpr-page">
         <div className="fpr-card">
-          <div className="fpr-back" onClick={() => navigate("/forgot/verify")}>← Back to Code</div>
+          <div
+            className="fpr-back"
+            onClick={() => navigate("/forgot/verify", { state: { email } })}
+          >
+            ← Back to Code
+          </div>
 
           <svg className="fpr-icon" xmlns="http://www.w3.org/2000/svg" height="40px" viewBox="0 -960 960 960" width="40px" fill="#0000F5" aria-hidden>
             <path d="M481-779.67q107.33 0 202.33 45.84 95 45.83 158 131.83 4.34 6.33 3.17 10.67-1.17 4.33-5.17 8-4 3.66-9.66 3.5Q824-580 819.33-586q-57.66-80.67-147.5-123.83Q582-753 481-753q-101 0-189.33 43.5-88.34 43.5-147 123.5-4.67 6.33-9.67 7.33t-9.67-2q-5-3-5.5-8.5t2.84-10.83q62-85.67 156.5-132.67 94.5-47 201.83-47Zm0 95.34q135.67 0 233 90 97.33 90 97.33 222.33 0 47.33-34.5 79.83t-83.5 32.5q-49.66 0-85.16-32.5T572.67-372q0-37-27.17-61.83-27.17-24.84-64.5-24.84t-64.83 24.84Q388.67-409 388.67-372q0 101.67 61.16 169.67Q511-134.33 604-107q7 2.33 9 6.67 2 4.33.67 9.66-1.34 5.67-5.34 8.67T598-81q-103.33-26-169.67-103.17Q362-261.33 362-372q0-48 35-80.67 35-32.66 84-32.66t84 32.66Q600-420 600-372q0 36.33 28 61.17Q656-286 693.33-286 730-286 757-310.83q27-24.84 27-61.17 0-120.67-89.33-202.33Q605.33-656 481.33-656T268-574.33q-89.33 81.66-89.33 202 0 24 5.16 61.66Q189-273 206.67-224.33 209-218 206.5-214t-7.17 6.33q-5.33 2.34-10.83.5-5.5-1.83-7.83-7.83-13.67-38.33-20.84-77.5-7.16-39.17-7.16-79.5 0-130.33 97.5-221.33t230.83-91Zm0-195.34q64.67 0 126.67 15.84 62 15.83 119 44.83 6.33 3 7.16 8 .84 5-1.5 9.33-2.33 4.34-7 7Q720.67-792 714-795q-54.33-27-113.17-42.17Q542-852.33 481-852.33q-60.67 0-118.67 14.16-58 14.17-111 43.17-6 3-10.33 1.17-4.33-1.84-7-6.5-2.67-4-2-8.84.67-4.83 5.33-7.83Q294-847.67 356-863.67t125-16Zm0 295q92.33 0 159 61.5T706.67-372q0 6.33-3.5 9.83t-9.84 3.5q-6 0-10-3.5t-4-9.83q0-79-58.83-132.5T481-558q-80.67 0-138.5 53.5T284.67-372q0 83.67 29 142.5t85.66 117.83Q404-107 403.67-102q-.34 5-4.34 9-3.33 3.33-9 4.33-5.66 1-10.33-4.33-58.33-60.67-90.5-126.17T257.33-372q0-89.67 65.67-151.17 65.67-61.5 158-61.5ZM480-386q6.33 0 9.83 4t3.5 10q0 79 57.67 130t133.67 51q7.33 0 18.33-1 11-1 23.67-3 6.33-1.33 10.5 1.83 4.16 3.17 5.5 8.17 1.33 5.33-1.34 9.33-2.66 4-8.66 5.34-18 5-31.5 5.5t-16.5.5q-88.34 0-153.17-59-64.83-59-64.83-148.67 0-6 3.5-10t9.83-4Z"/>
@@ -227,7 +250,14 @@ export default function ForgotPasswordReset() {
             </div>
 
             <div className="fpr-actions" style={{ marginTop: 16 }}>
-              <button type="button" className="fpr-btn" onClick={() => navigate("/forgot/verify")} style={{ marginRight: 12 }}>Back to code</button>
+              <button
+                type="button"
+                className="fpr-btn"
+                onClick={() => navigate("/forgot/verify", { state: { email } })}
+                style={{ marginRight: 12 }}
+              >
+                Back to code
+              </button>
               <button type="submit" className="fpr-btn primary" disabled={loading}>{loading ? "Submitting..." : "Submit"}</button>
             </div>
           </form>

--- a/src/routes/ForgotPassword/ForgotPasswordVerify.jsx
+++ b/src/routes/ForgotPassword/ForgotPasswordVerify.jsx
@@ -4,10 +4,16 @@ import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { API_BASE_URL, parseJsonSafe } from "../../utils/authApi";
 
+const FORGOT_PASSWORD_EMAIL_KEY = "nutrihelp.forgotPassword.email";
+const FORGOT_PASSWORD_RESET_TOKEN_KEY = "nutrihelp.forgotPassword.resetToken";
+
 export default function ForgotPasswordVerify() {
   const location = useLocation();
   const navigate = useNavigate();
-  const providedEmail = (location && location.state && location.state.email) || "";
+  const providedEmail =
+    (location && location.state && location.state.email) ||
+    sessionStorage.getItem(FORGOT_PASSWORD_EMAIL_KEY) ||
+    "";
 
   const [email] = useState(providedEmail);
   const [code, setCode] = useState(["", "", "", "", "", ""]);
@@ -20,6 +26,12 @@ export default function ForgotPasswordVerify() {
   useEffect(() => {
     setResendTimer(30);
     setCanResend(false);
+  }, [email]);
+
+  useEffect(() => {
+    if (email) {
+      sessionStorage.setItem(FORGOT_PASSWORD_EMAIL_KEY, email);
+    }
   }, [email]);
 
   useEffect(() => {
@@ -88,11 +100,23 @@ export default function ForgotPasswordVerify() {
         const d = await parseJsonSafe(res);
         throw new Error(d.error || d.message || "Invalid code");
       }
-      const data = await parseJsonSafe(res);
+      const payload = await parseJsonSafe(res);
+      const responseData =
+        payload && typeof payload === "object" && payload.data && typeof payload.data === "object"
+          ? payload.data
+          : payload;
+
+      const resetToken = responseData?.resetToken;
+      if (!resetToken) {
+        throw new Error("Reset token was not returned. Please verify the code again.");
+      }
+
+      sessionStorage.setItem(FORGOT_PASSWORD_EMAIL_KEY, email);
+      sessionStorage.setItem(FORGOT_PASSWORD_RESET_TOKEN_KEY, resetToken);
       navigate("/forgot/reset", {
         state: {
           email,
-          resetToken: data.resetToken,
+          resetToken,
         },
       });
     } catch (err) {

--- a/src/routes/Login/Login.jsx
+++ b/src/routes/Login/Login.jsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState, useContext, useEffect } from "react"
-import { Eye, EyeOff, UserIcon } from "lucide-react"
+import { Eye, EyeOff } from "lucide-react"
 import loginImage from "../../images/Nutrihelp.jpg"
 import logoImage from "../../images/logos_black_icon.png"
 
@@ -223,7 +223,7 @@ export default function Login() {
     },
     cardForm: {
       width: "60%",
-      padding: "45px 55px",
+      padding: "40px 52px",
       overflowY: "auto",
     },
     logoBlock: {
@@ -251,12 +251,14 @@ export default function Login() {
       textAlign: "center",
     },
     subtitle: {
-      marginBottom: "22px",
+      marginBottom: "20px",
       fontSize: "15px",
       color: "#555",
+      textAlign: "center",
+      lineHeight: 1.5,
     },
     field: {
-      marginBottom: "14px",
+      marginBottom: "12px",
     },
     label: {
       fontSize: "14px",
@@ -327,7 +329,7 @@ export default function Login() {
       display: "flex",
       justifyContent: "space-between",
       alignItems: "center",
-      margin: "10px 0 14px 0",
+      margin: "8px 0 12px 0",
       flexWrap: "wrap",
       gap: "10px",
     },
@@ -359,13 +361,14 @@ export default function Login() {
       cursor: "pointer",
       fontSize: "15px",
       fontWeight: 600,
-      marginBottom: "14px",
+      marginBottom: "12px",
       fontFamily: "inherit",
       transition: "all 0.2s ease",
     },
     switchText: {
-      marginBottom: "20px",
+      marginBottom: "16px",
       fontSize: "14px",
+      textAlign: "center",
     },
     switchLink: {
       color: "black",
@@ -375,7 +378,7 @@ export default function Login() {
     },
     divider: {
       textAlign: "center",
-      margin: "8px 0 18px 0",
+      margin: "4px 0 14px 0",
       position: "relative",
       fontSize: "14px",
     },
@@ -389,24 +392,37 @@ export default function Login() {
     },
     socialBox: {
       display: "flex",
-      gap: "15px",
+      justifyContent: "center",
+      width: "100%",
     },
     socialBtn: {
-      flex: 1,
-      padding: "12px",
+      width: "100%",
+      maxWidth: "340px",
+      padding: "13px 22px",
       borderRadius: "8px",
       border: "1px solid black",
       backgroundColor: "white",
       display: "flex",
       justifyContent: "center",
       alignItems: "center",
-      gap: "6px",
+      gap: "10px",
       cursor: "pointer",
       fontSize: "14px",
       fontWeight: 600,
       fontFamily: "inherit",
       transition: "all 0.3s ease",
       minHeight: "48px",
+      color: "#111111",
+      whiteSpace: "nowrap",
+    },
+    socialBtnLabel: {
+      fontSize: "14px",
+      fontWeight: 600,
+      lineHeight: 1,
+      color: "#111111",
+      display: "inline-block",
+      opacity: 1,
+      visibility: "visible",
     },
   }
 
@@ -451,6 +467,7 @@ export default function Login() {
         @media (max-width: 480px) {
           .card-image { height: 180px !important; }
           .card-form { padding: 24px 16px !important; }
+          .login-social-btn { max-width: 100% !important; }
         }
       `}</style>
 
@@ -545,8 +562,8 @@ export default function Login() {
 
           {/* Social Buttons */}
           <div style={styles.socialBox}>
-            <button style={styles.socialBtn} className="social-btn" onClick={handleGoogleSignIn}>
-              <span style={{ fontSize: "18px" }}>
+            <button type="button" style={styles.socialBtn} className="login-social-btn" onClick={handleGoogleSignIn}>
+              <span aria-hidden="true" style={{ display: "flex", alignItems: "center" }}>
                 <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 48 48">
                   <path
                     fill="#FFC107"
@@ -566,13 +583,7 @@ export default function Login() {
                   ></path>
                 </svg>
               </span>
-            </button>
-            <button style={styles.socialBtn} className="social-btn">
-              <span style={{ fontSize: "18px" }}>
-                <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 50 50">
-                  <path d="M 44.527344 34.75 C 43.449219 37.144531 42.929688 38.214844 41.542969 40.328125 C 39.601563 43.28125 36.863281 46.96875 33.480469 46.992188 C 30.46875 47.019531 29.691406 45.027344 25.601563 45.0625 C 21.515625 45.082031 20.664063 47.03125 17.648438 47 C 14.261719 46.96875 11.671875 43.648438 9.730469 40.699219 C 4.300781 32.429688 3.726563 22.734375 7.082031 17.578125 C 9.457031 13.921875 13.210938 11.773438 16.738281 11.773438 C 20.332031 11.773438 22.589844 13.746094 25.558594 13.746094 C 28.441406 13.746094 30.195313 11.769531 34.351563 11.769531 C 37.492188 11.769531 40.8125 13.480469 43.1875 16.433594 C 35.421875 20.691406 36.683594 31.78125 44.527344 34.75 Z M 31.195313 8.46875 C 32.707031 6.527344 33.855469 3.789063 33.4375 1 C 30.972656 1.167969 28.089844 2.742188 26.40625 4.78125 C 24.878906 6.640625 23.613281 9.398438 24.105469 12.066406 C 26.796875 12.152344 29.582031 10.546875 31.195313 8.46875 Z"></path>
-                </svg>
-              </span>
+              <span style={styles.socialBtnLabel}>Continue with Google</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the Apple login button and rebalance the Google login button on the login screen
- improve the Google login button label and spacing so the social sign-in area looks centered and complete
- fix the forgot-password verify/reset handoff so the reset token is read from the API response correctly and survives navigation or refresh during the reset flow

## What file changed
- `src/routes/Login/Login.jsx`
  - removed the Apple login button and related icon usage
  - reworked the Google login button layout, width, spacing, and label presentation
  - tightened spacing around the lower login actions for a more balanced layout

- `src/routes/ForgotPassword/ForgotPasswordVerify.jsx`
  - fixed reset-token extraction from the password verify response envelope
  - stored the email and reset token in `sessionStorage` so the next step keeps the required state

- `src/routes/ForgotPassword/ForgotPasswordReset.jsx`
  - added fallback reads from `sessionStorage` for `email` and `resetToken`
  - preserved the email when navigating back to the code screen
  - cleared temporary forgot-password session state after a successful password reset
