### PR TITLE
BE40: Profile Recovery & User Preference Flow Stabilization

### DIFF
--- a/src/components/WaterTracker.jsx
+++ b/src/components/WaterTracker.jsx
@@ -245,12 +245,13 @@ const WaterTracker = () => {
 
     if (currentUser && currentUser.id) {
        try {
-         const response = await fetch(`${process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081'}/api/water-intake`, {
+         const response = await fetch(`${process.env.REACT_APP_API_BASE_URL || 'https://localhost:8443'}/api/water-intake`, {
            method: 'POST',
            headers: { 'Content-Type': 'application/json' },
            body: JSON.stringify({
              user_id: currentUser.id,
-             glasses_consumed: newGlasses
+             amount_ml: newGlasses * 250,
+             date: new Date().toISOString().split('T')[0]
            })
          });
          const data = await response.json();

--- a/src/routes/LeaderBoard/components/FitnessInput.jsx
+++ b/src/routes/LeaderBoard/components/FitnessInput.jsx
@@ -145,6 +145,8 @@ import {
 import FieldError from "../../../components/FieldError";
 import { toast } from "react-toastify";
 
+const FITNESS_JOURNEY_STORAGE_KEY = "fitnessJourneyProfile";
+
 const FitnessInput = ({ onProfileSaved }) => {
   const [currentFitness, setCurrentFitness] = useState({
     weight: "",
@@ -221,29 +223,15 @@ const FitnessInput = ({ onProfileSaved }) => {
         endGoal: targetFitness.endGoal,
       };
 
-      // Sends the data to the backend API using fetch
       try {
-        const response = await fetch(
-          `${process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081'}/api/fitness-journey`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(data),
-          },
-        );
-
-        const result = await response.json();
-
-        if (response.ok) {
-          toast.success("Fitness journey saved successfully!");
-          onProfileSaved(); // If you want to redirect or show something do it here after saving the data successfully...
-        } else {
-          toast.error(`Error: ${result?.error || "Something went wrong"}`);
-        }
+        localStorage.setItem(FITNESS_JOURNEY_STORAGE_KEY, JSON.stringify({
+          ...data,
+          updatedAt: new Date().toISOString(),
+        }));
+        toast.success("Fitness journey saved locally.");
+        onProfileSaved();
       } catch (error) {
-        toast.error(`Network error: ${error.message}`);
+        toast.error(`Unable to save fitness journey: ${error.message}`);
       }
     }
   };

--- a/src/routes/LeaderBoard/components/FitnessJourney.jsx
+++ b/src/routes/LeaderBoard/components/FitnessJourney.jsx
@@ -118,6 +118,8 @@ import WeeklyPlanView from "./WeeklyPlanView.jsx"; // adjust path as needed
 import StatsView from "./StatsView.jsx";
 import "./FitnessJourney.css";
 
+const FITNESS_JOURNEY_STORAGE_KEY = "fitnessJourneyProfile";
+
 const FitnessJourney = () => {
   const [fitnessData, setFitnessData] = useState(null);
   const [visibleWeeks, setVisibleWeeks] = useState(12);
@@ -127,17 +129,17 @@ const FitnessJourney = () => {
   const [activePage, setActivePage] = useState("weekly");
 
   useEffect(() => {
-    const fetchFitnessData = async () => {
-      try {
-        const res = await fetch(`${process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081'}/api/fitness-Journey`);
-        const data = await res.json();
-        setFitnessData(Array.isArray(data) ? data[data.length - 1] : data);
-      } catch (error) {
-        console.error("Error fetching fitness data:", error);
-      }
-    };
-
-    fetchFitnessData();
+    try {
+      const stored = localStorage.getItem(FITNESS_JOURNEY_STORAGE_KEY);
+      if (!stored) return;
+      const data = JSON.parse(stored);
+      setFitnessData({
+        ...data,
+        target_weight: data?.targetWeight ?? data?.target_weight,
+      });
+    } catch (error) {
+      console.error("Error loading fitness journey data:", error);
+    }
   }, []);
 
   const handleWeekClick = (week) => {
@@ -203,4 +205,3 @@ const FitnessJourney = () => {
 };
 
 export default FitnessJourney;
-

--- a/src/services/notificationPreferencesApi.js
+++ b/src/services/notificationPreferencesApi.js
@@ -2,7 +2,7 @@
  * API Service for managing user notification preferences
  * Integrates with the extended user preferences API
  */
-const API_BASE_URL = `${process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081'}/api`;
+const API_BASE_URL = `${process.env.REACT_APP_API_BASE_URL || 'https://localhost:8443'}/api`;
 
 class NotificationPreferencesApi {
     constructor() {
@@ -192,12 +192,26 @@ class NotificationPreferencesApi {
                 throw new Error('User ID not found');
             }
 
+            const responsePayload = {
+                user: { userId },
+                ...preferences,
+            };
+
+            const hasUiSettings =
+                preferences?.ui_settings &&
+                typeof preferences.ui_settings === 'object';
+
+            if (!hasUiSettings) {
+                responsePayload.ui_settings = {
+                    language: preferences?.language || 'en',
+                    theme: preferences?.theme || 'light',
+                    font_size: preferences?.font_size || '16px',
+                };
+            }
+
             const response = await this.request('/user/preferences/extended', {
-                method: 'POST',
-                body: JSON.stringify({
-                    user: { userId },
-                    ...preferences
-                })
+                method: 'PUT',
+                body: JSON.stringify(responsePayload)
             });
             
             if (response.success) {


### PR DESCRIPTION
## Summary
- send water intake data in the backend-supported `amount_ml` format
- save the fitness journey flow locally instead of calling missing backend routes
- switch extended preference updates to `PUT` and ensure `ui_settings` is populated before submission

## What files changed
- `src/components/WaterTracker.jsx`
- `src/routes/LeaderBoard/components/FitnessInput.jsx`
- `src/routes/LeaderBoard/components/FitnessJourney.jsx`
- `src/services/notificationPreferencesApi.js`

## Testing
- not run end-to-end
- verified the branch contains only preference and progress flow updates
