### PR TITLE
Sync web hydration and scan history with shared user data

### DIFF
--- a/src/components/WaterTracker.jsx
+++ b/src/components/WaterTracker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useContext, useRef, useCallback } from "react";
 import { UserContext } from "../context/user.context";
+import BaseApi from "../services/baseApi";
 import "./WaterTracker.css";
 
 const DAILY_GOAL_CUPS = 8;
@@ -151,6 +152,13 @@ const CONFETTI_COLORS = [
   "#eab308",
 ];
 
+const api = new BaseApi();
+
+const getWaterStorageKey = (userId) => {
+  const scope = userId || "guest";
+  return `water_tracker_data.${scope}`;
+};
+
 const CONFETTI_PIECES = Array.from({ length: 28 }, (_, index) => {
   const angle = (index / 28) * Math.PI * 2;
   const radius = 74 + (index % 5) * 10;
@@ -179,15 +187,16 @@ const WaterTracker = () => {
   // Initialize from LocalStorage
   useEffect(() => {
     const today = getLocalDateString();
-    const storedDataStr = localStorage.getItem("water_tracker_data");
+    const userId = currentUser ? String(currentUser.id || currentUser.user_id || "guest") : "guest";
+    const storageKey = getWaterStorageKey(userId);
+    const storedDataStr = localStorage.getItem(storageKey);
     if (storedDataStr) {
       try {
         const storedData = JSON.parse(storedDataStr);
-        const userId = currentUser ? currentUser.id : "guest";
         if (storedData.date === today && storedData.userId === userId) {
           setGlasses(storedData.glasses || 0);
         } else {
-          localStorage.setItem("water_tracker_data", JSON.stringify({
+          localStorage.setItem(storageKey, JSON.stringify({
             date: today,
             userId,
             glasses: 0
@@ -198,13 +207,60 @@ const WaterTracker = () => {
         console.error("Failed to parse water tracker data", e);
       }
     } else {
-      const userId = currentUser ? currentUser.id : "guest";
-      localStorage.setItem("water_tracker_data", JSON.stringify({
+      localStorage.setItem(storageKey, JSON.stringify({
         date: today,
         userId,
         glasses: 0
       }));
     }
+  }, [currentUser]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadRemoteWater = async () => {
+      const currentUserId = currentUser?.id || currentUser?.user_id;
+      if (!currentUserId) return;
+
+      try {
+        const response = await fetch(
+          `${process.env.REACT_APP_API_BASE_URL || 'https://localhost:8443'}/api/water-intake?date=${encodeURIComponent(new Date().toISOString().split('T')[0])}`,
+          {
+            method: "GET",
+            headers: api.getHeaders(),
+          }
+        );
+
+        const payload = await response.json().catch(() => []);
+        if (!response.ok || cancelled) return;
+
+        const rows = Array.isArray(payload) ? payload : [];
+        const amountMl = rows.reduce((maxValue, row) => {
+          const currentValue = Number(row?.amount_ml || 0);
+          return currentValue > maxValue ? currentValue : maxValue;
+        }, 0);
+
+        const remoteGlasses = Math.round(amountMl / 250);
+        setGlasses(remoteGlasses);
+
+        localStorage.setItem(
+          getWaterStorageKey(String(currentUserId)),
+          JSON.stringify({
+            date: getLocalDateString(),
+            userId: String(currentUserId),
+            glasses: remoteGlasses,
+          })
+        );
+      } catch (error) {
+        console.error("Failed to load remote water intake", error);
+      }
+    };
+
+    loadRemoteWater();
+
+    return () => {
+      cancelled = true;
+    };
   }, [currentUser]);
 
   // Sync reminder flag from Settings storage
@@ -236,24 +292,23 @@ const WaterTracker = () => {
     setGlasses(newGlasses);
     
     const today = getLocalDateString();
-    const userId = currentUser ? currentUser.id : "guest";
-    localStorage.setItem("water_tracker_data", JSON.stringify({
+    const userId = currentUser ? String(currentUser.id || currentUser.user_id || "guest") : "guest";
+    localStorage.setItem(getWaterStorageKey(userId), JSON.stringify({
       date: today,
       userId,
       glasses: newGlasses
     }));
 
-    if (currentUser && currentUser.id) {
+    if (currentUser && (currentUser.id || currentUser.user_id)) {
        try {
          const response = await fetch(`${process.env.REACT_APP_API_BASE_URL || 'https://localhost:8443'}/api/water-intake`, {
            method: 'POST',
-           headers: { 'Content-Type': 'application/json' },
-           body: JSON.stringify({
-             user_id: currentUser.id,
-             amount_ml: newGlasses * 250,
-             date: new Date().toISOString().split('T')[0]
-           })
-         });
+            headers: api.getHeaders(),
+            body: JSON.stringify({
+              amount_ml: newGlasses * 250,
+              date: new Date().toISOString().split('T')[0]
+            })
+          });
          const data = await response.json();
          if (!response.ok) {
            throw new Error(data.error || 'Failed to sync water intake');

--- a/src/routes/UI-Only-Pages/ScanProducts/UploadHistory.js
+++ b/src/routes/UI-Only-Pages/ScanProducts/UploadHistory.js
@@ -1,15 +1,34 @@
 import React, { useEffect, useState } from 'react';
 import './ScanProducts.css';
 import SubHeading from '../../../components/general_components/headings/SubHeading';
+import { fetchMealLogs } from '../../../services/mealLogApi';
 
 function UploadHistory() {
   const [history, setHistory] = useState([]);
 
   useEffect(() => {
-    const storedHistory = localStorage.getItem('uploadHistory');
-    if (storedHistory) {
-      setHistory(JSON.parse(storedHistory));
+    let cancelled = false;
+
+    async function loadHistory() {
+      try {
+        const remoteHistory = await fetchMealLogs();
+        if (!cancelled) {
+          setHistory(Array.isArray(remoteHistory) ? remoteHistory : []);
+        }
+      } catch (error) {
+        console.error('Failed to load remote scan history, falling back to local uploadHistory.', error);
+        const storedHistory = localStorage.getItem('uploadHistory');
+        if (!cancelled && storedHistory) {
+          setHistory(JSON.parse(storedHistory));
+        }
+      }
     }
+
+    loadHistory();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (
@@ -21,7 +40,7 @@ function UploadHistory() {
         <ul className="scanned-products-list">
           {history.map((entry, index) => (
             <li key={index}>
-              {entry.time} - {entry.imageName}
+              {entry.created_at || entry.time || 'Saved'} - {entry.label || entry.imageName || entry.name || 'Scanned item'}
             </li>
           ))}
         </ul>

--- a/src/utils/scanLogStorage.js
+++ b/src/utils/scanLogStorage.js
@@ -1,6 +1,36 @@
 const SCAN_LOG_STORAGE_KEY = "nutrihelp_scan_log_v1";
 const SCAN_LOG_UPDATED_EVENT = "nutrihelp:scan-log-updated";
 
+function getCurrentUserScope() {
+  if (typeof window === "undefined") return "guest";
+
+  const candidates = [
+    window.localStorage.getItem("user"),
+    window.localStorage.getItem("user_session"),
+    window.sessionStorage.getItem("user"),
+    window.sessionStorage.getItem("user_session"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const parsed = JSON.parse(candidate);
+      const userId = parsed?.user_id || parsed?.id || parsed?.uid || parsed?.sub;
+      if (userId) {
+        return `user_${userId}`;
+      }
+    } catch {
+      // Ignore malformed storage entries and continue scanning.
+    }
+  }
+
+  return "guest";
+}
+
+function getScanLogStorageKey() {
+  return `${SCAN_LOG_STORAGE_KEY}.${getCurrentUserScope()}`;
+}
+
 function normalize(value) {
   return String(value || "").trim().toLowerCase();
 }
@@ -30,7 +60,7 @@ function toArray(rawValue) {
 function readRawScanLogEntries() {
   if (typeof window === "undefined") return [];
   try {
-    const raw = localStorage.getItem(SCAN_LOG_STORAGE_KEY);
+    const raw = localStorage.getItem(getScanLogStorageKey());
     const parsed = raw ? JSON.parse(raw) : [];
     return toArray(parsed);
   } catch {
@@ -41,7 +71,7 @@ function readRawScanLogEntries() {
 function writeRawScanLogEntries(entries) {
   if (typeof window === "undefined") return;
   try {
-    localStorage.setItem(SCAN_LOG_STORAGE_KEY, JSON.stringify(entries));
+    localStorage.setItem(getScanLogStorageKey(), JSON.stringify(entries));
     window.dispatchEvent(new Event(SCAN_LOG_UPDATED_EVENT));
   } catch {
     // Ignore storage write errors to keep UI responsive.


### PR DESCRIPTION
## Summary
- align web hydration state more closely with backend-backed daily water intake instead of relying only on local browser state
- scope local scan bookmark storage by authenticated user to avoid cross-user leakage on shared machines
- move upload history toward a shared cross-platform source by loading remote meal log history first and falling back to legacy local storage only when needed

## What files changed
- `src/components/WaterTracker.jsx`
- `src/utils/scanLogStorage.js`
- `src/routes/UI-Only-Pages/ScanProducts/UploadHistory.js`

## Testing
- reviewed hydration flow against:
  - `GET /api/water-intake`
  - `POST /api/water-intake`
- reviewed upload history flow against:
  - `GET /ai-model/meals/logs`
- verified local scan log storage now uses a user-scoped key
- verified upload history now prefers remote meal-log history and falls back to legacy `uploadHistory` only on failure
- not run full browser end-to-end in this final pass