### PR TITLE
AI018 polish scan image review flow

### DIFF
--- a/src/routes/DailyPlan/DailyPlanEdit.jsx
+++ b/src/routes/DailyPlan/DailyPlanEdit.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import {
   BarChart3,
   CalendarDays,
@@ -288,7 +288,11 @@ function getHealthTip(progressMap) {
 
 export default function DailyPlanEdit() {
   const navigate = useNavigate();
-  const [selectedDate, setSelectedDate] = useState(() => toISODate(new Date()));
+  const location = useLocation();
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("date") || toISODate(new Date());
+  });
   const [selectionsByDate, setSelectionsByDate] = useState(() => readSelectionsByDate());
   const [aiSuggestions, setAiSuggestions] = useState([]);
   const [aiLoading, setAiLoading] = useState(false);
@@ -296,6 +300,16 @@ export default function DailyPlanEdit() {
   const [deletingIds, setDeletingIds] = useState(() => new Set());
 
   const selectedDateObj = useMemo(() => fromISODate(selectedDate), [selectedDate]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const dateFromQuery = params.get("date");
+    const dateFromState = location.state?.selectedDate;
+    const nextDate = dateFromQuery || dateFromState;
+    if (nextDate) {
+      setSelectedDate(nextDate);
+    }
+  }, [location.search, location.state]);
 
   const yearOptions = useMemo(() => {
     const currentYear = new Date().getFullYear();

--- a/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.css
+++ b/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.css
@@ -490,6 +490,63 @@ html, body, #root, .App {
   align-items: flex-start;
 }
 
+.scan-review-stepper {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.scan-review-stepper button {
+  border: 1px solid var(--scan-line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.88);
+  color: var(--text-secondary);
+  padding: 12px 14px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.scan-review-stepper button.active {
+  background: linear-gradient(135deg, var(--scan-blue), var(--scan-teal));
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(7, 95, 184, 0.18);
+}
+
+.scan-step-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.scan-step-primary,
+.scan-step-secondary {
+  min-height: 46px;
+  border-radius: 999px;
+  padding: 0 20px;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.scan-step-primary {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--scan-blue), var(--scan-teal));
+  color: #fff;
+}
+
+.scan-step-secondary {
+  border: 1px solid var(--scan-line);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
+}
+
+.scan-step-primary:disabled,
+.scan-step-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .scan-review-kicker {
   display: inline-block;
   font-size: 0.82rem;
@@ -630,6 +687,97 @@ html, body, #root, .App {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.scan-profile-check-card {
+  margin: 0 1rem;
+  padding: 20px 22px;
+  border-radius: 22px;
+  background: linear-gradient(135deg, rgba(240, 253, 250, 0.92), rgba(239, 246, 255, 0.92));
+  border: 1px solid rgba(13, 148, 136, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.scan-profile-check-card h3 {
+  margin: 4px 0 0;
+  font-size: 1.2rem;
+  color: var(--text-primary);
+}
+
+.scan-profile-check-intro {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.scan-profile-check-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.scan-profile-check-tabs button {
+  border: 1px solid rgba(14, 116, 144, 0.24);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.84);
+  color: var(--text-primary);
+  padding: 10px 15px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.scan-profile-check-tabs button.active {
+  background: linear-gradient(135deg, #075fb8, #108a95);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 10px 22px rgba(7, 95, 184, 0.18);
+}
+
+.scan-profile-check-response {
+  display: grid;
+  gap: 8px;
+}
+
+.scan-profile-check-response p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.scan-profile-check-card small {
+  color: var(--text-secondary);
+  font-weight: 700;
+}
+
+.scan-profile-check-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.scan-profile-check-grid div {
+  border: 1px solid rgba(14, 116, 144, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 13px 14px;
+}
+
+.scan-profile-check-grid span {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  margin-bottom: 6px;
+}
+
+.scan-profile-check-grid strong {
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.scan-meal-info-copy.muted {
+  color: #64748b;
 }
 
 .scan-meal-info-header {
@@ -959,7 +1107,8 @@ html, body, #root, .App {
   .scan-review-banner,
   .scan-editable-grid,
   .scan-save-options-card,
-  .scan-save-options-grid {
+  .scan-save-options-grid,
+  .scan-review-stepper {
     grid-template-columns: 1fr;
   }
   .scan-review-banner {
@@ -985,6 +1134,19 @@ html, body, #root, .App {
   }
   .scan-meal-info-grid {
     grid-template-columns: 1fr;
+  }
+  .scan-profile-check-grid {
+    grid-template-columns: 1fr;
+  }
+  .scan-profile-check-tabs button {
+    flex: 1 1 140px;
+  }
+  .scan-step-actions {
+    flex-direction: column;
+  }
+  .scan-step-primary,
+  .scan-step-secondary {
+    width: 100%;
   }
 }
 
@@ -1206,6 +1368,7 @@ html, body, #root, .App {
 .scan-review-page .scan-review-banner,
 .scan-review-page .scan-editable-grid,
 .scan-review-page .scan-meal-info-card,
+.scan-review-page .scan-profile-check-card,
 .scan-review-page .scan-save-options-card,
 .scan-review-page .scan-quality-list,
 .scan-review-page .scan-error,
@@ -1216,6 +1379,7 @@ html, body, #root, .App {
 
 .scan-review-page .scan-review-banner,
 .scan-review-page .scan-meal-info-card,
+.scan-review-page .scan-profile-check-card,
 .scan-review-page .scan-save-options-card,
 .scan-review-page .scan-edit-card,
 .scan-review-page .scan-stat,
@@ -1970,6 +2134,110 @@ html, body, #root, .App {
 .scan-barcode-detection-list {
   margin-top: 8px !important;
   font-weight: 900;
+}
+
+.scan-save-confirmation-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  inset: 0;
+  z-index: 1200;
+  width: 100vw;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.36);
+  backdrop-filter: blur(6px);
+}
+
+.scan-save-confirmation-card {
+  width: min(480px, 100%);
+  border: 1px solid rgba(16, 185, 129, 0.28);
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(239, 253, 246, 0.96));
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.28);
+  padding: 28px;
+  color: var(--scan-ink);
+}
+
+.scan-save-confirmation-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: #047857;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.scan-save-confirmation-kicker::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #22c55e;
+  box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.14);
+}
+
+.scan-save-confirmation-card h3 {
+  margin: 0 0 10px;
+  padding: 0 !important;
+  color: var(--scan-ink);
+  font-size: clamp(1.55rem, 3vw, 2rem) !important;
+  line-height: 1.12;
+}
+
+.scan-save-confirmation-card p {
+  margin: 0 0 12px;
+  color: #475569;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.scan-save-confirmation-card small {
+  display: block;
+  margin-top: 8px;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.scan-save-confirmation-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 22px;
+  flex-wrap: wrap;
+}
+
+.scan-save-confirmation-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 132px;
+  min-height: 46px;
+  border-radius: 999px;
+  padding: 0 18px;
+  font-weight: 900;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.scan-save-confirmation-button-primary {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #075fb8, #108a95);
+  color: #fff;
+  box-shadow: 0 14px 28px rgba(7, 95, 184, 0.22);
+}
+
+.scan-save-confirmation-button-secondary {
+  border: 1px solid rgba(24, 58, 92, 0.18);
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--scan-ink);
 }
 
 .scan-barcode-table {

--- a/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.jsx
+++ b/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.jsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { toast } from "react-toastify";
 import "./ScanProducts.css";
 import { useLocation, useNavigate } from "react-router-dom";
-import { scanMultipleImages, scanSingleImage } from "../../../services/imageScanApi";
+import {
+  scanMultipleImages,
+  scanSingleImage,
+  verifyScanWithProfile,
+} from "../../../services/imageScanApi";
 import {
   fetchNutritionPreview,
   saveScannedMeal,
@@ -83,6 +88,32 @@ function hasBlockingPhotoIssue(issues = []) {
   );
 }
 
+function hasNonFoodPhotoIssue(issues = []) {
+  return issues.some((issue) =>
+    /people|screenshot|interface|non-food|rather than a clear food photo/i.test(issue)
+  );
+}
+
+function isRetakeOnlyScan(scanResult) {
+  if (!scanResult) return false;
+  const issues = scanResult.quality?.issues || [];
+  const foodProbability = Number(scanResult.food_probability ?? scanResult.foodProbability);
+  const confidence = normalizeConfidence(scanResult.confidence);
+  const lowFoodProbability = Number.isFinite(foodProbability) && foodProbability < 0.45;
+  const weakClosedSetGuess = confidence > 0 && confidence < 0.5;
+  const hasPhotoQualityBlocker = hasBlockingPhotoIssue(issues);
+  return Boolean(
+    scanResult.retake_needed &&
+      (
+        (lowFoodProbability && weakClosedSetGuess && hasPhotoQualityBlocker) ||
+        hasNonFoodPhotoIssue(issues) ||
+        /non-food|rather than a clear food|people|screenshot|interface/i.test(
+          `${scanResult.retake_reason || ""} ${scanResult.unclear_reason || ""}`
+        )
+      )
+  );
+}
+
 function normalizeMealTypeForDetail(value) {
   const normalized = String(value || "").trim().toLowerCase();
   if (normalized === "breakfast" || normalized === "lunch" || normalized === "dinner") {
@@ -112,9 +143,25 @@ function normalizeConfidence(value) {
   return Math.max(0, Math.min(1, decimalValue));
 }
 
+function formatProfileValue(items, fallback = "Not added yet") {
+  const values = Array.isArray(items)
+    ? items.map((item) => String(item || "").trim()).filter(Boolean)
+    : [];
+  return values.length ? values.join(", ") : fallback;
+}
+
 function getDefaultScanLabel(scanResult) {
   if (!scanResult) return "";
-  return scanResult.is_unclear ? "" : scanResult.label || scanResult.topk?.[0]?.label || "";
+  if (isRetakeOnlyScan(scanResult)) return "";
+  const firstSuggestedLabel = scanResult.topk?.[0]?.label || scanResult.matches?.[0]?.label || "";
+  if (firstSuggestedLabel) return firstSuggestedLabel;
+  return scanResult.is_unclear ? "" : scanResult.label || "";
+}
+
+function getScanNutritionPreview(label, scanResult) {
+  if (!label || !scanResult?.nutrition?.available) return null;
+  if (nutritionKey(label) !== nutritionKey(scanResult.label)) return null;
+  return normalizeNutritionPreview(label, scanResult.nutrition);
 }
 
 function clampReviewIndex(index, scanResults = []) {
@@ -371,9 +418,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
   const initialReviewIndex = clampReviewIndex(reviewPayload?.initialIndex, initialScanResults);
   const initialScanResult = initialScanResults[initialReviewIndex] || null;
   const initialLabel = getDefaultScanLabel(initialScanResult);
-  const initialNutritionPreview = initialLabel
-    ? normalizeNutritionPreview(initialLabel, initialScanResult?.nutrition)
-    : null;
+  const initialNutritionPreview = getScanNutritionPreview(initialLabel, initialScanResult);
   const [uploadedImages, setUploadedImages] = useState([]);
   const [previewUrls, setPreviewUrls] = useState(initialPreviewUrls);
   const [uploadPreviewIndex, setUploadPreviewIndex] = useState(0);
@@ -387,7 +432,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
   const [manualLabelInput, setManualLabelInput] = useState(initialLabel);
   const [nutritionPreview, setNutritionPreview] = useState(initialNutritionPreview);
   const [suggestedNutrition, setSuggestedNutrition] = useState(
-    initialLabel
+    initialLabel && initialNutritionPreview
       ? {
           [nutritionKey(initialLabel)]: initialNutritionPreview,
         }
@@ -408,6 +453,12 @@ function ScanProducts({ mode = "scan", embedded = false }) {
   const [isSavingScanLog, setIsSavingScanLog] = useState(false);
   const [isBookmarkTagDialogOpen, setIsBookmarkTagDialogOpen] = useState(false);
   const [bookmarkTag, setBookmarkTag] = useState(() => normalizeMealTypeForDetail("Lunch"));
+  const [scanProfileCheck, setScanProfileCheck] = useState(null);
+  const [isLoadingProfileCheck, setIsLoadingProfileCheck] = useState(false);
+  const [scanProfileCheckError, setScanProfileCheckError] = useState("");
+  const [profileCheckView, setProfileCheckView] = useState("advice");
+  const [scanReviewStep, setScanReviewStep] = useState("match");
+  const [saveConfirmation, setSaveConfirmation] = useState(null);
 
   const requiresConfirmation = Boolean(scanResult?.is_unclear);
   const hasConfidentScanLabel = Boolean(scanResult?.label && !requiresConfirmation);
@@ -428,6 +479,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
       !isSaving
   );
   const hasSuggestedMatches = Boolean(scanResult?.topk?.length);
+  const isRetakeOnly = isRetakeOnlyScan(scanResult);
   const hasPhotoIssue = hasBlockingPhotoIssue(scanResult?.quality?.issues || []);
 
   const selectedCandidate = useMemo(() => {
@@ -453,11 +505,14 @@ function ScanProducts({ mode = "scan", embedded = false }) {
   const photoQualityText = hasPhotoIssue ? "Try another photo" : "Good enough";
   const hasNutritionEstimate = nutritionPreview?.estimated_calories != null;
   const displayMealName =
-    nutritionPreview?.display_name || humanizeLabel(activeLabel) || "Choose a meal";
+    humanizeLabel(nutritionPreview?.display_name || activeLabel) || "Choose a meal";
+  const hasReviewSuggestion = Boolean(
+    requiresConfirmation && hasSuggestedMatches && activeLabel && !isRetakeOnly
+  );
   const scanReviewTitle = hasConfidentScanLabel
     ? humanizeLabel(scanResult.label)
-    : hasSuggestedMatches
-    ? "Review suggested matches"
+    : hasReviewSuggestion
+    ? `Suggested match: ${displayMealName}`
     : "No confident food match";
   const mealAboutText =
     nutritionPreview?.about ||
@@ -532,16 +587,14 @@ function ScanProducts({ mode = "scan", embedded = false }) {
     const nextScanResult = scanResults[reviewIndex] || null;
     const nextPreviewUrl = previewUrls[reviewIndex] || "";
     const defaultLabel = getDefaultScanLabel(nextScanResult);
-    const defaultPreview = defaultLabel
-      ? normalizeNutritionPreview(defaultLabel, nextScanResult?.nutrition)
-      : null;
+    const defaultPreview = getScanNutritionPreview(defaultLabel, nextScanResult);
 
     setPreviewUrl(nextPreviewUrl);
     setScanResult(nextScanResult);
     setSelectedLabel(defaultLabel);
     setManualLabelInput(defaultLabel);
     setSuggestedNutrition(
-      defaultLabel
+      defaultLabel && defaultPreview
         ? {
             [nutritionKey(defaultLabel)]: defaultPreview,
           }
@@ -554,6 +607,10 @@ function ScanProducts({ mode = "scan", embedded = false }) {
     setScanError("");
     setSaveMessage("");
     setIsBookmarkTagDialogOpen(false);
+    setScanProfileCheck(null);
+    setScanProfileCheckError("");
+    setProfileCheckView("advice");
+    setScanReviewStep("match");
   }, [isReviewMode, previewUrls, reviewIndex, scanResults]);
 
   useEffect(() => {
@@ -584,7 +641,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
       return undefined;
     }
 
-    if (activeLabel === scanResult.label && scanResult.nutrition) {
+    if (activeLabel === scanResult.label && scanResult.nutrition?.available) {
       const preview = normalizeNutritionPreview(activeLabel, scanResult.nutrition);
       setSuggestedNutrition((current) => ({
         ...current,
@@ -605,6 +662,57 @@ function ScanProducts({ mode = "scan", embedded = false }) {
 
     return () => clearTimeout(timer);
   }, [activeLabel, scanResult, suggestedNutrition]);
+
+  useEffect(() => {
+    if (!isReviewMode || !scanResult || !activeLabel) {
+      setScanProfileCheck(null);
+      setScanProfileCheckError("");
+      setIsLoadingProfileCheck(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setIsLoadingProfileCheck(true);
+      setScanProfileCheckError("");
+
+      const selectedCandidateForCheck =
+        scanResult.topk?.find((item) => nutritionKey(item.label) === nutritionKey(activeLabel)) ||
+        scanResult.matches?.find((item) => nutritionKey(item.label) === nutritionKey(activeLabel)) ||
+        null;
+
+      try {
+        const result = await verifyScanWithProfile({
+          ...scanResult,
+          selectedLabel: activeLabel,
+          confidence:
+            activeLabel === scanResult.label
+              ? scanResult.confidence
+              : selectedCandidateForCheck?.score ?? scanResult.confidence,
+          nutrition: nutritionPreview || scanResult.nutrition || {},
+        });
+
+        if (cancelled) return;
+        setScanProfileCheck(result);
+        setScanProfileCheckError("");
+      } catch (error) {
+        if (cancelled) return;
+        setScanProfileCheck(null);
+        setScanProfileCheckError(
+          error.message || "Profile-aware scan check is unavailable right now."
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoadingProfileCheck(false);
+        }
+      }
+    }, 450);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [activeLabel, isReviewMode, nutritionPreview, scanResult]);
 
   function handleSelectedLogDateChange(event) {
     const nextDate = event.target.value;
@@ -646,6 +754,11 @@ function ScanProducts({ mode = "scan", embedded = false }) {
     setNutritionPreview(null);
     setSuggestedNutrition({});
     setEditedCaloriesInput("");
+    setSaveConfirmation(null);
+    setScanProfileCheck(null);
+    setScanProfileCheckError("");
+    setProfileCheckView("advice");
+    setScanReviewStep("match");
     if (selectedFiles.length > MAX_IMAGE_COUNT) {
       setScanError(`You can upload up to ${MAX_IMAGE_COUNT} images at once.`);
     } else if (filteredFiles.length !== selectedFiles.length) {
@@ -724,9 +837,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
       writeScanReviewPayload(scanFlow);
       navigate("/scan-review", { state: { scanFlow } });
 
-      const defaultPreview = defaultLabel
-        ? normalizeNutritionPreview(defaultLabel, defaultScanResult?.nutrition)
-        : null;
+      const defaultPreview = getScanNutritionPreview(defaultLabel, defaultScanResult);
       setScanResults(scanResultList);
       setReviewIndex(0);
       setPreviewUrls(reviewPreviewUrls);
@@ -735,7 +846,7 @@ function ScanProducts({ mode = "scan", embedded = false }) {
       setSelectedLabel(defaultLabel);
       setManualLabelInput(defaultLabel);
       setSuggestedNutrition(
-        defaultLabel
+        defaultLabel && defaultPreview
           ? {
               [nutritionKey(defaultLabel)]: defaultPreview,
             }
@@ -982,7 +1093,16 @@ function ScanProducts({ mode = "scan", embedded = false }) {
         savedEntry.meal_type || selectedMealType
       } on ${savedDate}${syncedToMenu ? " and added it to your menu." : "."}`;
       setSaveMessage(successMessage);
-      toast.success(successMessage);
+      setSaveConfirmation({
+        dishName: humanizeLabel(savedEntry.label),
+        mealType: savedEntry.meal_type || selectedMealType,
+        date: savedDate,
+        syncedToMenu,
+      });
+      toast.success(successMessage, {
+        position: "top-right",
+        autoClose: 3500,
+      });
     } catch (error) {
       setScanError(error.message || "Failed to save meal log.");
     } finally {
@@ -1281,14 +1401,34 @@ function ScanProducts({ mode = "scan", embedded = false }) {
             </div>
           ) : null}
 
+          <div className="scan-review-stepper" aria-label="Scan review steps">
+            {[
+              ["match", "1. AI match"],
+              ["confirm", "2. Confirm"],
+              ["advice", "3. Profile advice"],
+              ["save", "4. Save"],
+            ].map(([step, label]) => (
+              <button
+                key={step}
+                type="button"
+                className={scanReviewStep === step ? "active" : ""}
+                onClick={() => setScanReviewStep(step)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {scanReviewStep === "match" ? (
+          <>
           <div className="scan-review-banner">
             <div>
               <span className="scan-review-kicker">AI suggestion</span>
               <h3>{scanReviewTitle}</h3>
               <p>
                 {requiresConfirmation
-                  ? hasSuggestedMatches
-                    ? "AI found possible matches but is not confident enough to confirm one automatically. Pick a suggestion if it looks right, or type the meal name yourself."
+                  ? hasSuggestedMatches && !isRetakeOnly
+                    ? `AI's closest match is ${displayMealName}, but it still needs your review. Pick another suggestion if it looks better, or type the meal name yourself.`
                     : "AI is not confident enough to confirm a dish from this image. Try another photo or type the meal name yourself."
                   : "This looks like a strong match. You can still adjust the meal name or calories if the serving looks different."}
               </p>
@@ -1311,6 +1451,50 @@ function ScanProducts({ mode = "scan", embedded = false }) {
               : "Check the meal name, dish information, and estimated calories below. If the serving is larger or smaller than usual, update it before saving."}
           </p>
 
+          {scanResult.topk?.length && !isRetakeOnly ? (
+            <div className="scan-suggestions-block">
+              <div className="scan-suggestions-header">
+                <h3>Similar matches</h3>
+                <p>Tap one to update the meal name, dish information, and starting calorie estimate for that match.</p>
+              </div>
+              <div className="scan-topk-list">
+              {scanResult.topk.map((item) => (
+                <button
+                  key={item.label}
+                  type="button"
+                  className={`scan-topk-option ${selectedLabel === item.label ? "active" : ""}`}
+                  onClick={() => handleCandidateSelect(item.label)}
+                >
+                  <span>{humanizeLabel(item.label)}</span>
+                  <strong>{requiresConfirmation ? "Review" : percent(item.score)}</strong>
+                </button>
+              ))}
+              </div>
+            </div>
+          ) : null}
+
+          {scanResult.quality?.issues?.length ? (
+            <ul className="scan-quality-list">
+              {scanResult.quality.issues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          ) : null}
+
+          <div className="scan-step-actions">
+            <button
+              type="button"
+              className="scan-step-primary"
+              onClick={() => setScanReviewStep("confirm")}
+            >
+              {activeLabel ? "Review this match" : "Enter meal manually"}
+            </button>
+          </div>
+          </>
+          ) : null}
+
+          {scanReviewStep === "confirm" ? (
+          <>
           <div className="scan-editable-grid">
             <label className="scan-edit-card">
               <span>Meal name</span>
@@ -1448,36 +1632,150 @@ function ScanProducts({ mode = "scan", embedded = false }) {
             </div>
           </div>
 
-          {scanResult.topk?.length ? (
-            <div className="scan-suggestions-block">
-              <div className="scan-suggestions-header">
-                <h3>Similar matches</h3>
-                <p>Tap one to update the meal name, dish information, and starting calorie estimate for that match.</p>
-              </div>
-              <div className="scan-topk-list">
-              {scanResult.topk.map((item) => (
-                <button
-                  key={item.label}
-                  type="button"
-                  className={`scan-topk-option ${selectedLabel === item.label ? "active" : ""}`}
-                  onClick={() => handleCandidateSelect(item.label)}
-                >
-                  <span>{humanizeLabel(item.label)}</span>
-                  <strong>{requiresConfirmation ? "Review" : percent(item.score)}</strong>
-                </button>
-              ))}
-              </div>
+          <div className="scan-step-actions">
+            <button type="button" className="scan-step-secondary" onClick={() => setScanReviewStep("match")}>
+              Back to AI match
+            </button>
+            <button
+              type="button"
+              className="scan-step-primary"
+              onClick={() => setScanReviewStep("advice")}
+              disabled={!activeLabel}
+            >
+              Check with my profile
+            </button>
+          </div>
+          </>
+          ) : null}
+
+          {scanReviewStep === "advice" ? (
+          <>
+          <div className="scan-profile-check-card">
+            <div>
+              <span className="scan-review-kicker">Profile-aware AI check</span>
+              <h3>Personal safety and suitability review</h3>
+              <p className="scan-profile-check-intro">
+                NutriHelp reviews the scan result with your saved food preferences and health profile.
+              </p>
             </div>
+            {isLoadingProfileCheck ? (
+              <p className="scan-meal-info-copy">
+                Checking this scan against your saved allergies, preferences, and health profile...
+              </p>
+            ) : scanProfileCheck?.verification ? (
+              <>
+                <div className="scan-profile-check-tabs" role="group" aria-label="Scan verification sections">
+                  {[
+                    ["advice", "AI advice"],
+                    ["scan", "Scan details"],
+                    ["profile", "Profile used"],
+                  ].map(([view, label]) => (
+                    <button
+                      key={view}
+                      type="button"
+                      className={profileCheckView === view ? "active" : ""}
+                      onClick={() => setProfileCheckView(view)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+
+                {profileCheckView === "advice" ? (
+                  <div className="scan-profile-check-response">
+                    {String(scanProfileCheck.verification)
+                      .split(/\n+/)
+                      .filter(Boolean)
+                      .slice(0, 4)
+                      .map((line) => (
+                        <p key={line}>{line.replace(/^[-*]\s*/, "")}</p>
+                      ))}
+                  </div>
+                ) : null}
+
+                {profileCheckView === "scan" ? (
+                  <div className="scan-profile-check-grid">
+                    <div>
+                      <span>Closest match</span>
+                      <strong>{humanizeLabel(scanProfileCheck.scanSummary?.label || activeLabel || "Not set")}</strong>
+                    </div>
+                    <div>
+                      <span>Confidence</span>
+                      <strong>{percent(scanProfileCheck.scanSummary?.confidence ?? scanResult?.confidence)}</strong>
+                    </div>
+                    <div>
+                      <span>Food probability</span>
+                      <strong>
+                        {scanProfileCheck.scanSummary?.foodProbability == null
+                          ? "Not available"
+                          : percent(scanProfileCheck.scanSummary.foodProbability)}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Top options</span>
+                      <strong>
+                        {formatProfileValue(scanProfileCheck.scanSummary?.topCandidates, "No clear options")}
+                      </strong>
+                    </div>
+                  </div>
+                ) : null}
+
+                {profileCheckView === "profile" ? (
+                  <div className="scan-profile-check-grid">
+                    <div>
+                      <span>Allergies/intolerances</span>
+                      <strong>{formatProfileValue(scanProfileCheck.profileSummary?.allergies)}</strong>
+                    </div>
+                    <div>
+                      <span>Diet</span>
+                      <strong>{formatProfileValue(scanProfileCheck.profileSummary?.dietaryRequirements)}</strong>
+                    </div>
+                    <div>
+                      <span>Disliked ingredients</span>
+                      <strong>{formatProfileValue(scanProfileCheck.profileSummary?.dislikedIngredients)}</strong>
+                    </div>
+                    <div>
+                      <span>Health conditions</span>
+                      <strong>{formatProfileValue(scanProfileCheck.profileSummary?.healthConditions)}</strong>
+                    </div>
+                  </div>
+                ) : null}
+
+                <small>
+                  {scanProfileCheck.profileAware
+                    ? "Based on your saved NutriHelp profile. Always confirm ingredients before eating."
+                    : "Complete your profile for a more personalised allergy and health check."}
+                </small>
+              </>
+            ) : scanProfileCheckError ? (
+              <p className="scan-meal-info-copy muted">
+                {scanProfileCheckError}
+              </p>
+            ) : (
+              <p className="scan-meal-info-copy muted">
+                Sign in and complete your profile to check this scan against allergies, preferences, and health goals.
+              </p>
+            )}
+          </div>
+
+          <div className="scan-step-actions">
+            <button type="button" className="scan-step-secondary" onClick={() => setScanReviewStep("confirm")}>
+              Back to confirm
+            </button>
+            <button
+              type="button"
+              className="scan-step-primary"
+              onClick={() => setScanReviewStep("save")}
+              disabled={!activeLabel}
+            >
+              Continue to save
+            </button>
+          </div>
+          </>
           ) : null}
 
-          {scanResult.quality?.issues?.length ? (
-            <ul className="scan-quality-list">
-              {scanResult.quality.issues.map((issue) => (
-                <li key={issue}>{issue}</li>
-              ))}
-            </ul>
-          ) : null}
-
+          {scanReviewStep === "save" ? (
+          <>
           <div className="scan-save-options-card">
             <div>
               <span className="scan-review-kicker">Save settings</span>
@@ -1522,7 +1820,51 @@ function ScanProducts({ mode = "scan", embedded = false }) {
               {isSaving ? "Saving..." : `Save to ${selectedMealType} on ${selectedLogDate || "selected date"}`}
             </button>
           </div>
+          </>
+          ) : null}
         </div>
+      ) : null}
+
+      {saveConfirmation ? createPortal(
+        <div
+          className="scan-save-confirmation-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="scan-save-confirmation-title"
+        >
+          <div className="scan-save-confirmation-card">
+            <span className="scan-save-confirmation-kicker">Meal saved</span>
+            <h3 id="scan-save-confirmation-title">Saved to your Daily Plan</h3>
+            <p>
+              {saveConfirmation.dishName} was saved to {saveConfirmation.mealType} on{" "}
+              {saveConfirmation.date}. You can review it in your Daily Plan now.
+            </p>
+            {saveConfirmation.syncedToMenu ? (
+              <small>The meal was also added to your local daily menu view.</small>
+            ) : null}
+            <div className="scan-save-confirmation-actions">
+              <button
+                type="button"
+                className="scan-save-confirmation-button scan-save-confirmation-button-secondary"
+                onClick={() => setSaveConfirmation(null)}
+              >
+                Stay here
+              </button>
+              <button
+                type="button"
+                className="scan-save-confirmation-button scan-save-confirmation-button-primary"
+                onClick={() =>
+                  navigate(`/daily-plan-edit?date=${encodeURIComponent(saveConfirmation.date)}`, {
+                    state: { selectedDate: saveConfirmation.date },
+                  })
+                }
+              >
+                Yes, open Daily Plan
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
       ) : null}
 
     </div>

--- a/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.test.jsx
+++ b/src/routes/UI-Only-Pages/ScanProducts/ScanProducts.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ScanProducts from './ScanProducts';
-import { BrowserRouter } from 'react-router-dom';
-import { scanMultipleImages } from '../../../services/imageScanApi';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { scanMultipleImages, scanSingleImage } from '../../../services/imageScanApi';
 import {
     fetchDailyMealSummary,
     fetchNutritionPreview,
@@ -20,17 +20,33 @@ const emptySummary = {
 
 const renderScanProducts = () => {
     return render(
-        <BrowserRouter>
-            <ScanProducts />
-        </BrowserRouter>
+        <MemoryRouter initialEntries={['/scan']}>
+            <Routes>
+                <Route path="/scan" element={<ScanProducts />} />
+                <Route path="/scan-review" element={<ScanProducts mode="review" />} />
+            </Routes>
+        </MemoryRouter>
     );
 };
+
+const getUploadInput = () => document.querySelector('#file-upload');
 
 describe('ScanProducts Integration Tests', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         global.URL.createObjectURL = jest.fn(() => 'blob:scan-preview');
         global.URL.revokeObjectURL = jest.fn();
+        global.FileReader = class {
+            readAsDataURL() {
+                this.result = 'data:image/jpeg;base64,test';
+                this.onload?.();
+            }
+        };
+        global.Image = class {
+            set src(_value) {
+                this.onerror?.();
+            }
+        };
         fetchDailyMealSummary.mockResolvedValue(emptySummary);
         fetchNutritionPreview.mockImplementation((label) =>
             Promise.resolve({
@@ -44,21 +60,19 @@ describe('ScanProducts Integration Tests', () => {
     });
 
     test('successfully uploads an image and renders scan result', async () => {
-        scanMultipleImages.mockResolvedValueOnce({
-            predictions: [{
+        scanSingleImage.mockResolvedValueOnce({
                 label: 'Apple',
                 confidence: 0.95,
                 topk: [{ label: 'Apple', score: 0.95 }],
                 matches: [{ label: 'Apple', score: 0.95 }],
                 is_unclear: false,
                 quality: { issues: [] },
-            }]
         });
 
         renderScanProducts();
 
         const file = new File(['dummy content'], 'apple.png', { type: 'image/png' });
-        const input = screen.getByLabelText(/Image/i);
+        const input = getUploadInput();
         
         fireEvent.change(input, { target: { files: [file] } });
 
@@ -66,8 +80,8 @@ describe('ScanProducts Integration Tests', () => {
         fireEvent.click(uploadButton);
 
         await waitFor(() => {
-            expect(scanMultipleImages).toHaveBeenCalledWith([file], { topk: 5 });
-            expect(screen.getByText(/Scan Result/i)).toBeTruthy();
+            expect(scanSingleImage).toHaveBeenCalledWith(file, { topk: 3 });
+            expect(screen.getAllByText(/Scan Result/i).length).toBeGreaterThan(0);
             expect(screen.getAllByText(/Apple/i).length).toBeGreaterThan(0);
         });
     });
@@ -83,7 +97,7 @@ describe('ScanProducts Integration Tests', () => {
     });
 
     test('handles backend error (500)', async () => {
-        scanMultipleImages.mockRejectedValueOnce({
+        scanSingleImage.mockRejectedValueOnce({
             message: 'Server Error',
             status: 500
         });
@@ -91,7 +105,7 @@ describe('ScanProducts Integration Tests', () => {
         renderScanProducts();
 
         const file = new File(['dummy content'], 'apple.png', { type: 'image/png' });
-        const input = screen.getByLabelText(/Image/i);
+        const input = getUploadInput();
         fireEvent.change(input, { target: { files: [file] } });
 
         const uploadButton = screen.getByRole('button', { name: /Analyze Image/i });
@@ -103,12 +117,12 @@ describe('ScanProducts Integration Tests', () => {
     });
 
     test('handles network error', async () => {
-        scanMultipleImages.mockRejectedValueOnce(new Error('Network Error'));
+        scanSingleImage.mockRejectedValueOnce(new Error('Network Error'));
 
         renderScanProducts();
 
         const file = new File(['dummy content'], 'apple.png', { type: 'image/png' });
-        const input = screen.getByLabelText(/Image/i);
+        const input = getUploadInput();
         fireEvent.change(input, { target: { files: [file] } });
 
         const uploadButton = screen.getByRole('button', { name: /Analyze Image/i });
@@ -145,32 +159,27 @@ describe('ScanProducts Integration Tests', () => {
 
         const file = new File(['dummy content'], 'banana.png', { type: 'image/png' });
         const secondFile = new File(['dummy content'], 'orange.png', { type: 'image/png' });
-        const input = screen.getByLabelText(/Image/i);
+        const input = getUploadInput();
         fireEvent.change(input, { target: { files: [file, secondFile] } });
 
         const uploadButton = screen.getByRole('button', { name: /Analyze Images/i });
         fireEvent.click(uploadButton);
 
         await waitFor(() => {
-            expect(scanMultipleImages).toHaveBeenCalledWith([file, secondFile], { topk: 5 });
+            expect(scanMultipleImages).toHaveBeenCalledWith([file, secondFile], { topk: 3 });
             expect(screen.getByText(/Scan Result 1/i)).toBeTruthy();
-            expect(screen.getByText(/Scan Result 2/i)).toBeTruthy();
             expect(screen.getAllByText(/Banana/i).length).toBeGreaterThan(0);
-            expect(screen.getAllByText(/Orange/i).length).toBeGreaterThan(0);
+            expect(screen.getByRole('button', { name: /Next image/i })).toBeTruthy();
         });
     });
 
     test('does not auto-fill meal info for retake review-only scans', async () => {
-        scanMultipleImages.mockResolvedValueOnce({
-            predictions: [{
-                label: 'meat_loaf',
-                confidence: 0.72,
+        scanSingleImage.mockResolvedValueOnce({
+                label: '',
+                confidence: 0.08,
                 retake_needed: true,
                 retake_reason: 'Image appears to be an illustration or portrait, not a clear food photo.',
-                topk: [
-                    { label: 'apple', score: 0.42 },
-                    { label: 'meat_loaf', score: 0.31 },
-                ],
+                topk: [],
                 matches: [],
                 is_unclear: true,
                 quality: {
@@ -179,28 +188,116 @@ describe('ScanProducts Integration Tests', () => {
                     ],
                 },
                 nutrition: {
-                    display_name: 'Meat Loaf',
-                    estimated_calories: 240,
-                    available: true,
+                    available: false,
                 },
-            }]
         });
 
         renderScanProducts();
 
         const file = new File(['dummy content'], 'not-food.png', { type: 'image/png' });
-        const input = screen.getByLabelText(/Image/i);
+        const input = getUploadInput();
         fireEvent.change(input, { target: { files: [file] } });
 
         const uploadButton = screen.getByRole('button', { name: /Analyze Image/i });
         fireEvent.click(uploadButton);
 
         await waitFor(() => {
-            expect(screen.getByText(/No clear food match/i)).toBeTruthy();
+            expect(screen.getByText(/No confident food match/i)).toBeTruthy();
+            expect(screen.getAllByText(/not a clear food photo/i).length).toBeGreaterThan(0);
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /Enter meal manually/i }));
+
+        await waitFor(() => {
             expect(screen.getAllByText(/Choose a meal/i).length).toBeGreaterThan(0);
-            expect(screen.getAllByText(/This image does not look like a clear food photo/i).length).toBeGreaterThan(0);
-            expect(screen.getByText(/Apple/i)).toBeTruthy();
-            expect(screen.getByText(/Meat Loaf/i)).toBeTruthy();
+        });
+    });
+
+    test('does not prefill closed-set food candidates for non-food retake scenes', async () => {
+        scanSingleImage.mockResolvedValueOnce({
+                label: 'frozen_yogurt',
+                confidence: 0.34,
+                food_probability: 0.31,
+                retake_needed: true,
+                retake_reason: 'Image appears to show people or a non-food scene rather than a clear meal photo.',
+                topk: [
+                    { label: 'frozen_yogurt', score: 0.34 },
+                    { label: 'ice_cream', score: 0.21 },
+                ],
+                matches: [],
+                is_unclear: true,
+                quality: {
+                    issues: [
+                        'Image appears to contain people rather than a clear food photo.',
+                        'Image appears blurry.',
+                    ],
+                },
+                nutrition: {
+                    available: false,
+                },
+        });
+
+        renderScanProducts();
+
+        const file = new File(['dummy content'], 'hospital.png', { type: 'image/png' });
+        const input = getUploadInput();
+        fireEvent.change(input, { target: { files: [file] } });
+
+        const uploadButton = screen.getByRole('button', { name: /Analyze Image/i });
+        fireEvent.click(uploadButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/No confident food match/i)).toBeTruthy();
+            expect(screen.queryByDisplayValue(/frozen_yogurt/i)).toBeNull();
+            expect(screen.queryByText(/Suggested match: Frozen Yogurt/i)).toBeNull();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /Enter meal manually/i }));
+
+        await waitFor(() => {
+            expect(screen.getAllByText(/Choose a meal/i).length).toBeGreaterThan(0);
+            expect(screen.queryByDisplayValue(/frozen_yogurt/i)).toBeNull();
+        });
+    });
+
+    test('pre-fills top suggestion for reviewable food scans', async () => {
+        scanSingleImage.mockResolvedValueOnce({
+                label: 'steak',
+                confidence: 0.34,
+                food_probability: 0.31,
+                retake_needed: true,
+                retake_reason: null,
+                topk: [
+                    { label: 'steak', score: 0.34 },
+                    { label: 'sushi', score: 0.21 },
+                ],
+                matches: [],
+                is_unclear: true,
+                quality: { issues: [] },
+                nutrition: {
+                    available: false,
+                },
+        });
+
+        renderScanProducts();
+
+        const file = new File(['dummy content'], 'steak.png', { type: 'image/png' });
+        const input = getUploadInput();
+        fireEvent.change(input, { target: { files: [file] } });
+
+        const uploadButton = screen.getByRole('button', { name: /Analyze Image/i });
+        fireEvent.click(uploadButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Suggested match: Steak/i)).toBeTruthy();
+            expect(fetchNutritionPreview).toHaveBeenCalledWith('steak');
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /Review this match/i }));
+
+        await waitFor(() => {
+            expect(screen.getByDisplayValue(/steak/i)).toBeTruthy();
+            expect(fetchNutritionPreview).toHaveBeenCalledWith('steak');
         });
     });
 });

--- a/src/services/imageScanApi.js
+++ b/src/services/imageScanApi.js
@@ -1,4 +1,5 @@
 import AIBaseApi from "./aiApi";
+import BaseApi from "./baseApi";
 
 class ImageScanApi extends AIBaseApi {
   async scanSingleImage(file, { topk = 3 } = {}) {
@@ -35,6 +36,28 @@ class ImageScanApi extends AIBaseApi {
   }
 }
 
+class ScanVerificationApi extends BaseApi {
+  async verifyScanWithProfile(scanResult) {
+    const token = this.getAuthToken();
+    if (!token || !scanResult) return null;
+
+    const response = await fetch(`${this.baseURL}/chatbot/scan-verification`, {
+      method: "POST",
+      headers: this.getHeaders(token),
+      body: JSON.stringify({ scan_result: scanResult }),
+    });
+
+    const data = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new Error(data?.message || data?.error || "Failed to verify scan with profile.");
+    }
+    return data;
+  }
+}
+
 export const imageScanApi = new ImageScanApi();
+export const scanVerificationApi = new ScanVerificationApi();
 export const scanSingleImage = (...args) => imageScanApi.scanSingleImage(...args);
 export const scanMultipleImages = (...args) => imageScanApi.scanMultipleImages(...args);
+export const verifyScanWithProfile = (...args) =>
+  scanVerificationApi.verifyScanWithProfile(...args);


### PR DESCRIPTION
## Summary
- Reworked the scan result page into a step-by-step review flow: AI match, confirmation, profile advice, and save.
- Added profile-aware AI scan advice using the new API verification endpoint.
- Prevented low-confidence but reviewable food scans from being hidden as “No confident food match”.
- Kept non-food or poor-quality scans in a safer review/manual-entry flow.
- Added a save success toast and a centered confirmation modal asking whether the user wants to open the Daily Plan.
- Updated Daily Plan navigation so saved scan meals open on the correct selected date.
- Added regression tests for reviewable food scans and non-food retake cases.

## Testing
- npm test -- --runTestsByPath src/routes/UI-Only-Pages/ScanProducts/ScanProducts.test.jsx --watchAll=false
