### PR TITLE
feat: add reusable guided tours for meal and recipe flows

### DIFF
--- a/src/components/GuidedTour/GuidedTour.css
+++ b/src/components/GuidedTour/GuidedTour.css
@@ -1,0 +1,168 @@
+.guided-tour-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 14000;
+  pointer-events: auto;
+  font-family: "Poppins", "Segoe UI", sans-serif;
+}
+
+.guided-tour-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 23, 43, 0.58);
+}
+
+.guided-tour-spotlight {
+  position: fixed;
+  border-radius: 50%;
+  border: 3px solid #93dbff;
+  box-shadow:
+    0 0 0 9999px rgba(10, 23, 43, 0.58),
+    0 0 0 6px rgba(147, 219, 255, 0.2),
+    0 0 28px rgba(80, 180, 255, 0.75);
+  animation: guided-tour-pulse 1.9s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.guided-tour-pointer {
+  position: fixed;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 91, 187, 0.35);
+  color: #005bbb;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.28);
+  animation: guided-tour-pointer-pop 1.15s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.guided-tour-panel {
+  position: fixed;
+  left: 50%;
+  bottom: max(16px, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  width: min(94vw, 620px);
+  background: #ffffff;
+  border-radius: 22px;
+  border: 1px solid rgba(0, 91, 187, 0.2);
+  box-shadow: 0 18px 36px rgba(14, 34, 64, 0.28);
+  padding: 22px 24px;
+  color: #10233d;
+}
+
+.guided-tour-step-label {
+  display: inline-block;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: #35557d;
+  margin-bottom: 8px;
+}
+
+.guided-tour-panel h2 {
+  margin: 0 0 10px;
+  font-size: clamp(1.25rem, 3vw, 1.65rem);
+  line-height: 1.2;
+  color: #0d2344;
+}
+
+.guided-tour-panel p {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.8vw, 1.2rem);
+  line-height: 1.55;
+  color: #223d62;
+}
+
+.guided-tour-actions {
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.guided-tour-btn {
+  min-height: 48px;
+  padding: 0 18px;
+  border-radius: 14px;
+  font-size: 1.02rem;
+  font-weight: 600;
+  border: 0;
+  cursor: pointer;
+  transition: transform 0.18s ease, filter 0.18s ease, background 0.18s ease;
+}
+
+.guided-tour-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.guided-tour-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+  filter: brightness(0.98);
+}
+
+.guided-tour-btn-secondary {
+  background: #eef4ff;
+  color: #103b73;
+  border: 1px solid rgba(16, 59, 115, 0.2);
+}
+
+.guided-tour-btn-primary {
+  margin-left: auto;
+  background: linear-gradient(135deg, #005bbb 0%, #1a7be0 100%);
+  color: #ffffff;
+  box-shadow: 0 10px 18px rgba(0, 91, 187, 0.28);
+}
+
+@keyframes guided-tour-pulse {
+  0% {
+    transform: scale(0.97);
+  }
+
+  50% {
+    transform: scale(1.04);
+  }
+
+  100% {
+    transform: scale(0.97);
+  }
+}
+
+@keyframes guided-tour-pointer-pop {
+  0% {
+    transform: scale(0.94);
+  }
+
+  50% {
+    transform: scale(1.02);
+  }
+
+  100% {
+    transform: scale(0.94);
+  }
+}
+
+@media (max-width: 700px) {
+  .guided-tour-panel {
+    border-radius: 18px;
+    padding: 18px;
+  }
+
+  .guided-tour-actions {
+    gap: 8px;
+  }
+
+  .guided-tour-btn {
+    flex: 1 1 calc(50% - 8px);
+    min-height: 46px;
+  }
+
+  .guided-tour-btn-primary {
+    margin-left: 0;
+  }
+}

--- a/src/components/GuidedTour/GuidedTour.jsx
+++ b/src/components/GuidedTour/GuidedTour.jsx
@@ -1,0 +1,297 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { MousePointerClick } from "lucide-react";
+import "./GuidedTour.css";
+
+const VIEWPORT_MARGIN = 12;
+const DEFAULT_SPOTLIGHT_PADDING = 16;
+const DEFAULT_SPOTLIGHT_MIN_SIZE = 84;
+const DEFAULT_SPOTLIGHT_MAX_SIZE = 260;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function safeNumeric(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toSelectorCandidates(step) {
+  if (!step) return [];
+
+  const selectors = [];
+  if (Array.isArray(step.targetSelectors)) {
+    step.targetSelectors.forEach((selector) => {
+      if (typeof selector === "string" && selector.trim()) selectors.push(selector.trim());
+    });
+  }
+
+  if (typeof step.targetSelector === "string" && step.targetSelector.trim()) {
+    selectors.push(step.targetSelector.trim());
+  }
+
+  const targetIds = [];
+  if (Array.isArray(step.targetIds)) {
+    step.targetIds.forEach((targetId) => {
+      if (typeof targetId === "string" && targetId.trim()) targetIds.push(targetId.trim());
+    });
+  } else if (typeof step.targetId === "string" && step.targetId.trim()) {
+    targetIds.push(step.targetId.trim());
+  }
+
+  targetIds.forEach((targetId) => {
+    const escaped = targetId.replace(/"/g, '\\"');
+    selectors.push(`[data-tour-id="${escaped}"]`);
+  });
+
+  return selectors;
+}
+
+function resolveTargetElement(step) {
+  if (typeof document === "undefined") return null;
+
+  const selectors = toSelectorCandidates(step);
+  for (const selector of selectors) {
+    try {
+      const element = document.querySelector(selector);
+      if (element) return element;
+    } catch {
+      // Ignore invalid selector and keep resolving the rest.
+    }
+  }
+
+  return null;
+}
+
+function computeSpotlight(targetRect, step, viewport) {
+  if (!targetRect || !viewport?.width || !viewport?.height) return null;
+
+  const minSize = safeNumeric(step?.spotlightMinSize, DEFAULT_SPOTLIGHT_MIN_SIZE);
+  const maxSize = safeNumeric(step?.spotlightMaxSize, DEFAULT_SPOTLIGHT_MAX_SIZE);
+  const padding = safeNumeric(step?.spotlightPadding, DEFAULT_SPOTLIGHT_PADDING);
+  const explicitSize = safeNumeric(step?.spotlightSize, 0);
+  const baseSize = explicitSize > 0
+    ? explicitSize
+    : Math.max(targetRect.width, targetRect.height) + padding * 2;
+
+  const maxViewportSize = Math.max(
+    64,
+    Math.min(viewport.width, viewport.height) - VIEWPORT_MARGIN * 2,
+  );
+
+  const diameter = clamp(baseSize, minSize, Math.min(maxSize, maxViewportSize));
+
+  const centerX = targetRect.left + targetRect.width / 2;
+  const centerY = targetRect.top + targetRect.height / 2;
+  const left = clamp(centerX - diameter / 2, VIEWPORT_MARGIN, viewport.width - diameter - VIEWPORT_MARGIN);
+  const top = clamp(centerY - diameter / 2, VIEWPORT_MARGIN, viewport.height - diameter - VIEWPORT_MARGIN);
+
+  const pointerLeft = clamp(left + diameter - 16, VIEWPORT_MARGIN, viewport.width - 44);
+  const pointerTop = clamp(top + diameter * 0.15, VIEWPORT_MARGIN, viewport.height - 44);
+
+  return {
+    diameter,
+    left,
+    top,
+    pointerLeft,
+    pointerTop,
+  };
+}
+
+export default function GuidedTour({
+  open,
+  steps,
+  restartKey = 0,
+  onFinish,
+  onSkip,
+}) {
+  const safeSteps = Array.isArray(steps) ? steps : [];
+  const [stepIndex, setStepIndex] = useState(0);
+  const [targetRect, setTargetRect] = useState(null);
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
+  const targetObserverRef = useRef(null);
+
+  const currentStep = safeSteps[stepIndex] || null;
+  const isLastStep = stepIndex === safeSteps.length - 1;
+
+  const updateTargetRect = useCallback(() => {
+    if (!open || !currentStep || typeof window === "undefined") return;
+
+    const targetElement = resolveTargetElement(currentStep);
+    if (!targetElement) {
+      setTargetRect(null);
+      return;
+    }
+
+    const nextRect = targetElement.getBoundingClientRect();
+    if (nextRect.width <= 0 || nextRect.height <= 0) {
+      setTargetRect(null);
+      return;
+    }
+
+    setTargetRect(nextRect);
+  }, [currentStep, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setStepIndex(0);
+  }, [open, restartKey]);
+
+  useEffect(() => {
+    if (!open || !currentStep) return;
+
+    const targetElement = resolveTargetElement(currentStep);
+    if (targetElement && currentStep.scrollIntoView !== false) {
+      targetElement.scrollIntoView({
+        behavior: "smooth",
+        block: currentStep.scrollBlock || "center",
+        inline: currentStep.scrollInline || "center",
+      });
+    }
+
+    const timer = window.setTimeout(() => {
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+      updateTargetRect();
+    }, 220);
+
+    return () => window.clearTimeout(timer);
+  }, [currentStep, open, updateTargetRect]);
+
+  useEffect(() => {
+    if (!open || !currentStep || typeof window === "undefined") return;
+
+    const syncLayout = () => {
+      setViewport({ width: window.innerWidth, height: window.innerHeight });
+      updateTargetRect();
+    };
+
+    syncLayout();
+
+    const targetElement = resolveTargetElement(currentStep);
+    if (targetObserverRef.current) {
+      targetObserverRef.current.disconnect();
+      targetObserverRef.current = null;
+    }
+
+    if (targetElement && typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(() => {
+        updateTargetRect();
+      });
+      observer.observe(targetElement);
+      targetObserverRef.current = observer;
+    }
+
+    window.addEventListener("resize", syncLayout);
+    window.addEventListener("scroll", updateTargetRect, true);
+
+    return () => {
+      window.removeEventListener("resize", syncLayout);
+      window.removeEventListener("scroll", updateTargetRect, true);
+      if (targetObserverRef.current) {
+        targetObserverRef.current.disconnect();
+        targetObserverRef.current = null;
+      }
+    };
+  }, [currentStep, open, updateTargetRect]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onSkip?.();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onSkip]);
+
+  const spotlight = useMemo(
+    () => computeSpotlight(targetRect, currentStep, viewport),
+    [currentStep, targetRect, viewport],
+  );
+
+  if (!open || !currentStep || safeSteps.length === 0 || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div className="guided-tour-overlay" role="dialog" aria-modal="true" aria-label="Add Meal Guide">
+      <div className="guided-tour-backdrop" />
+
+      {spotlight ? (
+        <>
+          <div
+            className="guided-tour-spotlight"
+            style={{
+              width: `${spotlight.diameter}px`,
+              height: `${spotlight.diameter}px`,
+              left: `${spotlight.left}px`,
+              top: `${spotlight.top}px`,
+            }}
+            aria-hidden="true"
+          />
+          <div
+            className="guided-tour-pointer"
+            style={{
+              left: `${spotlight.pointerLeft}px`,
+              top: `${spotlight.pointerTop}px`,
+            }}
+            aria-hidden="true"
+          >
+            <MousePointerClick size={24} strokeWidth={2.2} />
+          </div>
+        </>
+      ) : null}
+
+      <div className="guided-tour-panel">
+        <span className="guided-tour-step-label">Step {stepIndex + 1} of {safeSteps.length}</span>
+        <h2>{currentStep.title}</h2>
+        <p>{currentStep.description}</p>
+
+        <div className="guided-tour-actions">
+          <button
+            type="button"
+            className="guided-tour-btn guided-tour-btn-secondary"
+            onClick={() => setStepIndex((prev) => Math.max(0, prev - 1))}
+            disabled={stepIndex === 0}
+          >
+            Back
+          </button>
+
+          <button
+            type="button"
+            className="guided-tour-btn guided-tour-btn-secondary"
+            onClick={() => onSkip?.()}
+          >
+            Skip
+          </button>
+
+          {isLastStep ? (
+            <button
+              type="button"
+              className="guided-tour-btn guided-tour-btn-primary"
+              onClick={() => onFinish?.()}
+            >
+              Finish
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="guided-tour-btn guided-tour-btn-primary"
+              onClick={() => setStepIndex((prev) => Math.min(safeSteps.length - 1, prev + 1))}
+            >
+              Next
+            </button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/routes/CreateRecipe/CreateRecipe.css
+++ b/src/routes/CreateRecipe/CreateRecipe.css
@@ -100,6 +100,30 @@
   line-height: 1.55;
 }
 
+.create-recipe-guide-btn {
+  margin-top: 10px;
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 99, 183, 0.34);
+  background: linear-gradient(135deg, rgba(234, 242, 255, 0.96), rgba(216, 232, 255, 0.96));
+  color: #0f63b7;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 16px;
+  font-size: 0.9rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+}
+
+.create-recipe-guide-btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(0.98);
+  box-shadow: 0 10px 18px rgba(15, 99, 183, 0.18);
+}
+
 .create-recipe-page .bg-\[\#d8edfd\][id="no-bg"] {
   position: relative;
   border: 1px solid var(--recipe-border) !important;
@@ -317,6 +341,11 @@
 
   .create-recipe-hero {
     padding: 22px 18px;
+  }
+
+  .create-recipe-guide-btn {
+    width: 100%;
+    min-height: 42px;
   }
 
   .create-recipe-hero h1[id="no-bg"] {

--- a/src/routes/CreateRecipe/CreateRecipe.jsx
+++ b/src/routes/CreateRecipe/CreateRecipe.jsx
@@ -3,8 +3,10 @@ import { useRef, useState, useEffect, useMemo, useContext } from "react";
 import "./CreateRecipe.css";
 import { MdArrowDropDown, MdArrowDropUp, MdEdit } from "react-icons/md";
 import { RiDeleteBin6Fill } from "react-icons/ri";
+import { CircleHelp } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import FramerClient from "../../components/framer-client.jsx";
+import GuidedTour from "../../components/GuidedTour/GuidedTour";
 import {
   cuisineListDB,
   getCuisineList,
@@ -18,6 +20,77 @@ import { UserContext } from "../../context/user.context.jsx";
 import { ERROR_MESSAGES } from "../../utils/validationRules";
 import FieldError from "../../components/FieldError";
 import { toast } from "react-toastify";
+import {
+  setCrossPageTourFlowStage,
+} from "../../utils/crossPageTourFlow";
+
+const CREATE_SEARCH_TOUR_FLOW_ID = "create-to-search-recipes";
+const CREATE_RECIPE_TOUR_STATE_KEY = "nutrihelp_create_recipe_tour_state_v1";
+
+const CREATE_RECIPE_TOUR_STEPS = [
+  {
+    targetId: "create-recipe-hero",
+    title: "Create recipe here",
+    description: "This page lets you create your own recipe step by step.",
+    spotlightSize: 220,
+  },
+  {
+    targetId: "create-recipe-name-input",
+    title: "Enter recipe name",
+    description: "Start by typing a simple recipe name.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "create-recipe-cuisine-select",
+    title: "Choose cuisine type",
+    description: "Pick the cuisine that matches your recipe.",
+    spotlightSize: 195,
+  },
+  {
+    targetId: "create-recipe-add-ingredient-button",
+    title: "Add ingredient",
+    description: "Fill ingredient fields, then press Add.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "create-recipe-add-instruction-button",
+    title: "Add instruction step",
+    description: "Write a cooking step, then press Add.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "create-recipe-save-button",
+    title: "Save your recipe",
+    description: "When ready, press Save Recipe.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "create-recipe-guide-button",
+    title: "Continue to Search Recipes",
+    description: "Press Finish to open Search Recipes and continue the guide.",
+    spotlightSize: 170,
+  },
+];
+
+function readCreateRecipeTourStateFromStorage() {
+  if (typeof window === "undefined") return "";
+
+  try {
+    return localStorage.getItem(CREATE_RECIPE_TOUR_STATE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeCreateRecipeTourStateToStorage(nextState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(CREATE_RECIPE_TOUR_STATE_KEY, nextState);
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
+}
 
 // Create Recipe page
 function CreateRecipe() {
@@ -424,6 +497,51 @@ function CreateRecipe() {
   };
 
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const [isCreateRecipeTourOpen, setIsCreateRecipeTourOpen] = useState(false);
+  const [createRecipeTourRestartKey, setCreateRecipeTourRestartKey] = useState(0);
+  const [hasSeenCreateRecipeTour, setHasSeenCreateRecipeTour] = useState(false);
+  const [isCreateRecipeTourStateReady, setIsCreateRecipeTourStateReady] = useState(false);
+
+  const closeCreateRecipeTour = (nextState) => {
+    setIsCreateRecipeTourOpen(false);
+    if (!nextState) return;
+    writeCreateRecipeTourStateToStorage(nextState);
+    setHasSeenCreateRecipeTour(true);
+  };
+
+  const handleOpenCreateRecipeTour = () => {
+    setIsCreateRecipeTourOpen(true);
+    setCreateRecipeTourRestartKey((previous) => previous + 1);
+  };
+
+  const handleSkipCreateRecipeTour = () => {
+    closeCreateRecipeTour("skipped");
+  };
+
+  const handleFinishCreateRecipeTour = () => {
+    closeCreateRecipeTour("completed");
+    setCrossPageTourFlowStage(CREATE_SEARCH_TOUR_FLOW_ID, "search-pending");
+    navigate("/searchRecipes");
+  };
+
+  useEffect(() => {
+    const persistedState = readCreateRecipeTourStateFromStorage();
+    setHasSeenCreateRecipeTour(persistedState === "completed" || persistedState === "skipped");
+    setIsCreateRecipeTourStateReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isCreateRecipeTourStateReady) return;
+    if (hasSeenCreateRecipeTour) return;
+    if (isCreateRecipeTourOpen) return;
+
+    const timerId = window.setTimeout(() => {
+      setIsCreateRecipeTourOpen(true);
+      setCreateRecipeTourRestartKey((previous) => previous + 1);
+    }, 450);
+
+    return () => window.clearTimeout(timerId);
+  }, [hasSeenCreateRecipeTour, isCreateRecipeTourOpen, isCreateRecipeTourStateReady]);
 
   //==================== Render the component ====================
   return (
@@ -451,7 +569,7 @@ function CreateRecipe() {
                 id="no-bg"
               //className="flex flex-col bg-[#E8F1FF] sm:flex-row justify-between items-center mb-6 sm:mb-8 md:mb-10 lg:mb-12"
               >
-                <div id="no-bg" className="create-recipe-hero w-full flex justify-center">
+                <div id="no-bg" className="create-recipe-hero w-full flex justify-center" data-tour-id="create-recipe-hero">
                   <span className="create-recipe-kicker">Personal Recipe Builder</span>
                   <h1
                     id="no-bg"
@@ -462,6 +580,16 @@ function CreateRecipe() {
                   <p className="create-recipe-subtitle">
                     Add the essentials only. NutriHelp will save your recipe privately and show it in My Recipes.
                   </p>
+                  <button
+                    type="button"
+                    className="create-recipe-guide-btn"
+                    onClick={handleOpenCreateRecipeTour}
+                    data-tour-id="create-recipe-guide-button"
+                    aria-label="Open Create Recipe guide"
+                  >
+                    <CircleHelp size={18} />
+                    Guide
+                  </button>
                 </div>
               </div>
               {/* Recipe Description Section */}
@@ -501,6 +629,7 @@ function CreateRecipe() {
                         value={formData.recipeName}
                         onChange={(e) => handleFieldChange("recipeName", e.target.value)}
                         onBlur={() => setTouched(prev => ({ ...prev, recipeName: true }))}
+                        data-tour-id="create-recipe-name-input"
                       />
                       <FieldError error={errors.recipeName} touched={touched.recipeName} />
                     </div>
@@ -522,6 +651,7 @@ function CreateRecipe() {
                         value={formData.cuisine}
                         onChange={(e) => handleFieldChange("cuisine", e.target.value)}
                         onBlur={() => setTouched(prev => ({ ...prev, cuisine: true }))}
+                        data-tour-id="create-recipe-cuisine-select"
                       >
                         <option value="">Select Cuisine Type</option>
                         {cuisineOptions}
@@ -865,6 +995,7 @@ function CreateRecipe() {
                           id="no-bg"
                           className="font-[Arial] bg-[#005BBB] text-white px-4 sm:px-6 py-2 sm:py-3 rounded-full font-semibold text-sm sm:text-base"
                           onClick={() => handelIngredientsInTable()}
+                          data-tour-id="create-recipe-add-ingredient-button"
                         >
                           Add
                         </button>
@@ -1097,6 +1228,7 @@ function CreateRecipe() {
                         setErrors((prev) => ({ ...prev, instructions: undefined }));
                         setFormData((prev) => ({ ...prev, currentInstruction: "" }));
                       }}
+                      data-tour-id="create-recipe-add-instruction-button"
                     >
                       Add
                     </button>
@@ -1111,6 +1243,7 @@ function CreateRecipe() {
                   id="no-bg"
                   // disabled={!instructions.trim()}
                   className="font-[Arial] bg-[#005BBB] text-white w-full max-w-xs px-8 py-3 rounded-full font-semibold text-lg shadow-xl shadow-blue-800/50  hover:bg-[#003f8a] transition duration-300"
+                  data-tour-id="create-recipe-save-button"
                 >
                   Save  Recipe
                 </button>
@@ -1119,6 +1252,14 @@ function CreateRecipe() {
           </div>
         </form>
       </div>
+
+      <GuidedTour
+        open={isCreateRecipeTourOpen}
+        steps={CREATE_RECIPE_TOUR_STEPS}
+        restartKey={createRecipeTourRestartKey}
+        onFinish={handleFinishCreateRecipeTour}
+        onSkip={handleSkipCreateRecipeTour}
+      />
     </FramerClient>
   );
 }

--- a/src/routes/Meal/Meal.css
+++ b/src/routes/Meal/Meal.css
@@ -1676,12 +1676,21 @@
 }
 
 /* ── Page-level tab switcher ─────────────────────────────────────────────── */
+.meal-tab-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
 .meal-tab-switcher {
   display: flex;
   gap: 8px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
   border-bottom: 2px solid var(--line);
   padding-bottom: 0;
+  flex: 1;
 }
 
 .meal-tab-btn {
@@ -1711,14 +1720,50 @@
   border-bottom-color: var(--brand);
 }
 
+.add-meal-guide-btn {
+  min-height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 91, 187, 0.35);
+  background: linear-gradient(135deg, rgba(234, 242, 255, 0.96), rgba(216, 232, 255, 0.96));
+  color: #0d4f9e;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+}
+
+.add-meal-guide-btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(0.98);
+  box-shadow: 0 10px 18px rgba(0, 91, 187, 0.18);
+}
+
 /* ── Personalized plan section ───────────────────────────────────────────── */
 .personalized-plan-section {
   padding-top: 8px;
 }
 
 @media (max-width: 640px) {
+  .meal-tab-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
   .meal-tab-btn {
     padding: 8px 14px;
+    font-size: 0.875rem;
+  }
+
+  .add-meal-guide-btn {
+    width: 100%;
+    min-height: 42px;
     font-size: 0.875rem;
   }
 }

--- a/src/routes/Meal/Meal.jsx
+++ b/src/routes/Meal/Meal.jsx
@@ -7,6 +7,7 @@ import {
   Check,
   Calculator,
   CalendarDays,
+  CircleHelp,
   ChevronLeft,
   Clock3,
   Search,
@@ -25,6 +26,7 @@ import {
 } from "../../utils/mealSelectionStorage";
 import html2canvas from "html2canvas";
 import jsPDF from "jspdf";
+import GuidedTour from "../../components/GuidedTour/GuidedTour";
 import PersonalizedPlanForm from "./PersonalizedPlanForm";
 import PersonalizedWeeklyPlan from "./PersonalizedWeeklyPlan";
 
@@ -50,6 +52,62 @@ const FLOATING_STACK_GAP = 12;
 const DEFAULT_WIDGET_BOTTOM = DEFAULT_FLOATING_BOTTOM + 48 + FLOATING_STACK_GAP;
 const RECOMMENDED_SCROLLBAR_INSET = 2;
 const RECOMMENDED_SCROLLBAR_MIN_THUMB = 56;
+const ADD_MEAL_TOUR_STATE_KEY = "nutrihelp_add_meal_tour_state_v1";
+
+const ADD_MEAL_TOUR_STEPS = [
+  {
+    targetId: "add-meal-tab-button",
+    title: "Welcome to Add Meal",
+    description: "This page helps you plan meals one step at a time.",
+    spotlightSize: 170,
+  },
+  {
+    targetId: "add-meal-date-control",
+    title: "Choose a date",
+    description: "First, pick the day you want to plan for.",
+    spotlightSize: 180,
+  },
+  {
+    targetId: "add-meal-breakfast-filter",
+    title: "Pick meal time",
+    description: "Choose Breakfast, Lunch, or Dinner here.",
+    spotlightSize: 175,
+  },
+  {
+    targetId: "add-meal-search-control",
+    title: "Search meals",
+    description: "Type a meal name here to find options quickly.",
+    spotlightSize: 210,
+  },
+  {
+    targetIds: [
+      "add-meal-first-recommended-card",
+      "add-meal-first-all-card",
+      "add-meal-all-section",
+    ],
+    title: "Select a meal card",
+    description: "Click a meal card to add it to your plan.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "add-meal-selected-total",
+    title: "Check it was added",
+    description: "Great. This number goes up when a meal is added.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "add-meal-view-plan-button",
+    title: "Review your saved plan",
+    description: "Press View Meal Plan to review your saved meals.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "add-meal-guide-button",
+    title: "Replay anytime",
+    description: "Need help again? Press Guide any time.",
+    spotlightSize: 165,
+  },
+];
 
 function getTodayISO() {
   const now = new Date();
@@ -59,6 +117,26 @@ function getTodayISO() {
 
 function readSelectionsByDateFromStorage() {
   return readMealSelectionsByDateFromStorage();
+}
+
+function readAddMealTourStateFromStorage() {
+  if (typeof window === "undefined") return "";
+
+  try {
+    return localStorage.getItem(ADD_MEAL_TOUR_STATE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeAddMealTourStateToStorage(nextState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(ADD_MEAL_TOUR_STATE_KEY, nextState);
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
 }
 
 function shiftISODate(isoDate, days) {
@@ -1074,12 +1152,66 @@ const Meal = () => {
   const [isRecipeLibraryLoading, setIsRecipeLibraryLoading] = useState(true);
   const [recipeLibraryError, setRecipeLibraryError] = useState("");
 
-  const [activeTab, setActiveTab] = useState('addMeal');
+  const [activeTab, setActiveTab] = useState("addMeal");
   const [planFilters, setPlanFilters] = useState(null);
+  const [isAddMealTourOpen, setIsAddMealTourOpen] = useState(false);
+  const [addMealTourRestartKey, setAddMealTourRestartKey] = useState(0);
+  const [hasSeenAddMealTour, setHasSeenAddMealTour] = useState(false);
+  const [isAddMealTourStateReady, setIsAddMealTourStateReady] = useState(false);
+
+  const closeAddMealTour = useCallback((nextState) => {
+    setIsAddMealTourOpen(false);
+
+    if (!nextState) return;
+    writeAddMealTourStateToStorage(nextState);
+    setHasSeenAddMealTour(true);
+  }, []);
+
+  const handleOpenAddMealTour = useCallback(() => {
+    setActiveTab("addMeal");
+    setActiveFilter("all");
+    setQuery("");
+    setIsSuggestionOpen(false);
+    setIsNutritionCollapsed(false);
+    setIsAddMealTourOpen(true);
+    setAddMealTourRestartKey((previous) => previous + 1);
+  }, []);
+
+  const handleFinishAddMealTour = useCallback(() => {
+    closeAddMealTour("completed");
+  }, [closeAddMealTour]);
+
+  const handleSkipAddMealTour = useCallback(() => {
+    closeAddMealTour("skipped");
+  }, [closeAddMealTour]);
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [location.pathname, location.search]);
+
+  useEffect(() => {
+    const persistedState = readAddMealTourStateFromStorage();
+    setHasSeenAddMealTour(persistedState === "completed" || persistedState === "skipped");
+    setIsAddMealTourStateReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isAddMealTourStateReady) return;
+    if (hasSeenAddMealTour) return;
+    if (isAddMealTourOpen) return;
+    if (activeTab !== "addMeal") return;
+
+    const timerId = window.setTimeout(() => {
+      setActiveFilter("all");
+      setQuery("");
+      setIsSuggestionOpen(false);
+      setIsNutritionCollapsed(false);
+      setIsAddMealTourOpen(true);
+      setAddMealTourRestartKey((previous) => previous + 1);
+    }, 450);
+
+    return () => window.clearTimeout(timerId);
+  }, [activeTab, hasSeenAddMealTour, isAddMealTourOpen, isAddMealTourStateReady]);
 
   useEffect(() => {
     const requestedFilter = resolveInitialMealFilter(location, preselectedMealType);
@@ -1858,25 +1990,39 @@ const Meal = () => {
           <span className="crumb-current">Add Meal</span>
         </div>
 
-        <div className="meal-tab-switcher">
+        <div className="meal-tab-header">
+          <div className="meal-tab-switcher">
+            <button
+              type="button"
+              className={`meal-tab-btn ${activeTab === "addMeal" ? "active" : ""}`}
+              onClick={() => setActiveTab("addMeal")}
+              data-tour-id="add-meal-tab-button"
+            >
+              Add Meal
+            </button>
+            <button
+              type="button"
+              className={`meal-tab-btn ${activeTab === "personalizedPlan" ? "active" : ""}`}
+              onClick={() => setActiveTab("personalizedPlan")}
+            >
+              <Sparkles size={15} />
+              AI Personalized Plan
+            </button>
+          </div>
+
           <button
             type="button"
-            className={`meal-tab-btn ${activeTab === 'addMeal' ? 'active' : ''}`}
-            onClick={() => setActiveTab('addMeal')}
+            className="add-meal-guide-btn"
+            onClick={handleOpenAddMealTour}
+            data-tour-id="add-meal-guide-button"
+            aria-label="Open Add Meal guide"
           >
-            Add Meal
-          </button>
-          <button
-            type="button"
-            className={`meal-tab-btn ${activeTab === 'personalizedPlan' ? 'active' : ''}`}
-            onClick={() => setActiveTab('personalizedPlan')}
-          >
-            <Sparkles size={15} />
-            AI Personalized Plan
+            <CircleHelp size={18} />
+            Guide
           </button>
         </div>
 
-        {activeTab === 'addMeal' && (<>
+        {activeTab === "addMeal" && (<>
         <div className="add-meal-toolbar">
           <div className="add-meal-date-row" aria-label="Plan date controls">
             <button
@@ -1894,6 +2040,7 @@ const Meal = () => {
                 className="add-meal-date-display"
                 onClick={openDatePicker}
                 aria-label="Choose planning date"
+                data-tour-id="add-meal-date-control"
               >
                 <CalendarDays size={16} className="add-meal-date-icon" />
                 <span>{dateDisplayLabel}</span>
@@ -1923,7 +2070,7 @@ const Meal = () => {
           </div>
 
           <div className="add-meal-search-wrap" ref={searchWrapRef}>
-            <label className="add-meal-search" htmlFor="add-meal-search">
+            <label className="add-meal-search" htmlFor="add-meal-search" data-tour-id="add-meal-search-control">
               <Search size={22} strokeWidth={2.2} className="search-icon" />
               <input
                 id="add-meal-search"
@@ -1998,6 +2145,7 @@ const Meal = () => {
                 aria-selected={isActive}
                 className={`filter-chip ${isActive ? "active" : ""}`}
                 onClick={() => setActiveFilter(filter.key)}
+                data-tour-id={filter.key === "breakfast" ? "add-meal-breakfast-filter" : undefined}
               >
                 {filter.label}
               </button>
@@ -2146,7 +2294,7 @@ const Meal = () => {
                     ) : (
                       <div className="recommended-row-shell">
                         <div className="recommended-row" ref={recommendedRowRef}>
-                          {filteredRecommended.map((meal) => {
+                          {filteredRecommended.map((meal, index) => {
                             const mealSlotKey = getMealSlotKey(
                               meal,
                               meal.id || meal.recipeId || meal.title,
@@ -2170,6 +2318,7 @@ const Meal = () => {
                                 key={meal.id}
                                 className={`recommend-card ${isSelected ? "selected" : ""} ${isSelectedDish ? "selected-dish" : ""}`}
                                 onClick={() => toggleMealSelection(meal)}
+                                data-tour-id={index === 0 ? "add-meal-first-recommended-card" : undefined}
                               >
                                 <div className="recommend-image-wrap">
                                   <img
@@ -2264,7 +2413,7 @@ const Meal = () => {
                   </section>
                 ) : null}
 
-                <section className="add-meal-section">
+                <section className="add-meal-section" data-tour-id="add-meal-all-section">
                   <div className="section-title-row">
                     <h2 className="section-title">
                       {isScanLogView ? "Saved Scan Meals" : "All Meals & Recipes"}
@@ -2293,7 +2442,7 @@ const Meal = () => {
                   ) : (
                     <div className="all-meals-wrap">
                       <div className="all-meals-grid">
-                        {paginatedAllMeals.map((meal) => {
+                        {paginatedAllMeals.map((meal, index) => {
                           const mealSlotKey = getMealSlotKey(
                             meal,
                             meal.id || meal.recipeId || meal.title,
@@ -2317,6 +2466,7 @@ const Meal = () => {
                               key={meal.id}
                               className={`all-meal-card ${isSelected ? "selected" : ""} ${isSelectedDish ? "selected-dish" : ""}`}
                               onClick={() => toggleMealSelection(meal)}
+                              data-tour-id={index === 0 ? "add-meal-first-all-card" : undefined}
                             >
                               <div className="all-meal-image-wrap">
                                 <img
@@ -2485,7 +2635,7 @@ const Meal = () => {
 
               <div className="nutrition-section total-nutrition-section">
                 <h4>Total Nutrition</h4>
-                <p>Total items selected: {selectedCount}</p>
+                <p data-tour-id="add-meal-selected-total">Total items selected: {selectedCount}</p>
                 <ul className="nutrition-kpi-list">
                   <li>
                     <span>Calories</span>
@@ -2521,6 +2671,7 @@ const Meal = () => {
                       },
                     })
                   }
+                  data-tour-id="add-meal-view-plan-button"
                 >
                   View Meal Plan
                 </button>
@@ -2551,6 +2702,14 @@ const Meal = () => {
           </div>
         )}
       </div>
+
+      <GuidedTour
+        open={isAddMealTourOpen}
+        steps={ADD_MEAL_TOUR_STEPS}
+        restartKey={addMealTourRestartKey}
+        onFinish={handleFinishAddMealTour}
+        onSkip={handleSkipAddMealTour}
+      />
 
       <div
         ref={widgetFabRef}

--- a/src/routes/Meal/MealDetail.css
+++ b/src/routes/Meal/MealDetail.css
@@ -14,10 +14,19 @@
 .meal-detail-breadcrumb {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 10px;
   margin-bottom: 18px;
   color: #6a7280;
   font-size: 0.875rem;
+}
+
+.meal-detail-breadcrumb-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
 .meal-detail-back {
@@ -34,6 +43,29 @@
 
 .meal-detail-back:hover {
   color: #1f2937;
+}
+
+.meal-detail-guide-btn {
+  min-height: 38px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 91, 187, 0.35);
+  background: linear-gradient(135deg, rgba(234, 242, 255, 0.96), rgba(216, 232, 255, 0.96));
+  color: #0d4f9e;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 14px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, filter 0.18s ease, box-shadow 0.18s ease;
+}
+
+.meal-detail-guide-btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(0.98);
+  box-shadow: 0 8px 14px rgba(0, 91, 187, 0.16);
 }
 
 .meal-detail-divider {
@@ -578,6 +610,22 @@
 @media (max-width: 860px) {
   .meal-detail-page {
     padding: 14px 12px 34px;
+  }
+
+  .meal-detail-breadcrumb {
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .meal-detail-breadcrumb-left {
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .meal-detail-guide-btn {
+    width: 100%;
+    min-height: 36px;
   }
 
   .meal-detail-add-grid {

--- a/src/routes/Meal/MealDetail.jsx
+++ b/src/routes/Meal/MealDetail.jsx
@@ -2,15 +2,79 @@ import "./MealDetail.css";
 
 import React, { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
-import { CalendarDays, ChevronLeft, Cloud, Clock3, Moon, Plus, Star, Sun, Users } from "lucide-react";
+import {
+  CalendarDays,
+  ChevronLeft,
+  CircleHelp,
+  Cloud,
+  Clock3,
+  Moon,
+  Plus,
+  Star,
+  Sun,
+  Users,
+} from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { fetchDishImage } from "../../services/dishImageApi";
+import GuidedTour from "../../components/GuidedTour/GuidedTour";
 import {
   readMealSelectionsByDateFromStorage,
   writeMealSelectionsByDateToStorage,
 } from "../../utils/mealSelectionStorage";
 
 const DEFAULT_IMAGE = "/images/meal-mock/placeholder.svg";
+const MEAL_DETAIL_TOUR_STATE_KEY = "nutrihelp_meal_detail_tour_state_v1";
+
+const MEAL_DETAIL_TOUR_STEPS = [
+  {
+    targetId: "meal-detail-hero-section",
+    title: "Meal details here",
+    description: "This page shows nutrition, ingredients, and meal details.",
+    spotlightSize: 220,
+  },
+  {
+    targetId: "meal-detail-add-slot-breakfast",
+    title: "Choose meal time",
+    description: "Pick Breakfast, Lunch, or Dinner first.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "meal-detail-add-today-button",
+    title: "Add for today",
+    description: "Press here to add this meal to today's plan.",
+    spotlightSize: 190,
+  },
+  {
+    targetId: "meal-detail-specific-day-trigger",
+    title: "Add for another day",
+    description: "Use this button to choose a different date.",
+    spotlightSize: 190,
+  },
+  {
+    targetIds: ["meal-detail-specific-date-input", "meal-detail-specific-day-trigger"],
+    title: "Choose your date",
+    description: "Pick a date from today onward.",
+    spotlightSize: 195,
+  },
+  {
+    targetIds: ["meal-detail-specific-date-add", "meal-detail-specific-day-trigger"],
+    title: "Save this date",
+    description: "Press Add to save this meal for that day.",
+    spotlightSize: 180,
+  },
+  {
+    targetId: "meal-detail-view-recipe-button",
+    title: "Open full recipe",
+    description: "Use View Recipe to see full cooking instructions.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "meal-detail-guide-button",
+    title: "Replay this guide",
+    description: "Need help again? Press Guide any time.",
+    spotlightSize: 165,
+  },
+];
 
 const NUTRITION_PRESETS = {
   breakfast: { calories: 280, carbs: 45, protein: 10, fiber: 8, fat: 9, sodium: 140 },
@@ -239,6 +303,26 @@ function writeStoredSelections(nextValue) {
   }
 }
 
+function readMealDetailTourStateFromStorage() {
+  if (typeof window === "undefined") return "";
+
+  try {
+    return localStorage.getItem(MEAL_DETAIL_TOUR_STATE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeMealDetailTourStateToStorage(nextState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(MEAL_DETAIL_TOUR_STATE_KEY, nextState);
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
+}
+
 function removeDuplicateMealSelections(selectionMap, incomingMeal) {
   if (!selectionMap || typeof selectionMap !== "object") return {};
 
@@ -416,6 +500,52 @@ const MealDetail = () => {
   const [selectedAddTo, setSelectedAddTo] = useState(normalizePlanMealType(detail.mealType || "breakfast"));
   const [specificDate, setSpecificDate] = useState(todayIso);
   const [isSpecificDayPickerOpen, setIsSpecificDayPickerOpen] = useState(false);
+  const [isMealDetailTourOpen, setIsMealDetailTourOpen] = useState(false);
+  const [mealDetailTourRestartKey, setMealDetailTourRestartKey] = useState(0);
+  const [hasSeenMealDetailTour, setHasSeenMealDetailTour] = useState(false);
+  const [isMealDetailTourStateReady, setIsMealDetailTourStateReady] = useState(false);
+
+  const closeMealDetailTour = (nextState) => {
+    setIsMealDetailTourOpen(false);
+    setIsSpecificDayPickerOpen(false);
+    if (!nextState) return;
+    writeMealDetailTourStateToStorage(nextState);
+    setHasSeenMealDetailTour(true);
+  };
+
+  const handleOpenMealDetailTour = () => {
+    setIsSpecificDayPickerOpen(true);
+    setIsMealDetailTourOpen(true);
+    setMealDetailTourRestartKey((previous) => previous + 1);
+  };
+
+  const handleFinishMealDetailTour = () => {
+    closeMealDetailTour("completed");
+  };
+
+  const handleSkipMealDetailTour = () => {
+    closeMealDetailTour("skipped");
+  };
+
+  useEffect(() => {
+    const persistedState = readMealDetailTourStateFromStorage();
+    setHasSeenMealDetailTour(persistedState === "completed" || persistedState === "skipped");
+    setIsMealDetailTourStateReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMealDetailTourStateReady) return;
+    if (hasSeenMealDetailTour) return;
+    if (isMealDetailTourOpen) return;
+
+    const timerId = window.setTimeout(() => {
+      setIsSpecificDayPickerOpen(true);
+      setIsMealDetailTourOpen(true);
+      setMealDetailTourRestartKey((previous) => previous + 1);
+    }, 450);
+
+    return () => window.clearTimeout(timerId);
+  }, [hasSeenMealDetailTour, isMealDetailTourOpen, isMealDetailTourStateReady]);
 
   useEffect(() => {
     let isActive = true;
@@ -536,17 +666,35 @@ const MealDetail = () => {
     <div className="meal-detail-page">
       <div className="meal-detail-shell">
         <div className="meal-detail-breadcrumb" aria-label="breadcrumb">
-          <button type="button" className="meal-detail-back" onClick={() => navigate(-1)}>
-            <ChevronLeft size={14} />
-            Back
+          <div className="meal-detail-breadcrumb-left">
+            <button
+              type="button"
+              className="meal-detail-back"
+              onClick={() => navigate(-1)}
+              data-tour-id="meal-detail-back-button"
+            >
+              <ChevronLeft size={14} />
+              Back
+            </button>
+            <span className="meal-detail-divider">/</span>
+            <span className="meal-detail-muted">Meal Planning</span>
+            <span className="meal-detail-divider">/</span>
+            <span className="meal-detail-current">Dish Detail</span>
+          </div>
+
+          <button
+            type="button"
+            className="meal-detail-guide-btn"
+            onClick={handleOpenMealDetailTour}
+            data-tour-id="meal-detail-guide-button"
+            aria-label="Open meal detail guide"
+          >
+            <CircleHelp size={17} />
+            Guide
           </button>
-          <span className="meal-detail-divider">/</span>
-          <span className="meal-detail-muted">Meal Planning</span>
-          <span className="meal-detail-divider">/</span>
-          <span className="meal-detail-current">Dish Detail</span>
         </div>
 
-        <div className="meal-detail-hero">
+        <div className="meal-detail-hero" data-tour-id="meal-detail-hero-section">
           <section className="meal-detail-left">
             <div className="meal-detail-image-card">
               <img src={detailImage} alt={detail.title} loading="lazy" onError={handleImageError} />
@@ -594,6 +742,7 @@ const MealDetail = () => {
                       type="button"
                       className={`meal-detail-add-option ${isActive ? "active" : ""}`}
                       onClick={() => setSelectedAddTo(option.key)}
+                      data-tour-id={option.key === "breakfast" ? "meal-detail-add-slot-breakfast" : undefined}
                     >
                       <span className={`icon ${option.iconClass}`}>
                         <Icon size={16} strokeWidth={2.3} />
@@ -664,7 +813,12 @@ const MealDetail = () => {
 
           <div className="meal-detail-bottom-actions">
             <div className="meal-detail-actions">
-              <button type="button" className="meal-detail-action-btn primary" onClick={handleAddToday}>
+              <button
+                type="button"
+                className="meal-detail-action-btn primary"
+                onClick={handleAddToday}
+                data-tour-id="meal-detail-add-today-button"
+              >
                 <Plus size={16} />
                 Add to Today's Plan
               </button>
@@ -673,6 +827,7 @@ const MealDetail = () => {
                   type="button"
                   className="meal-detail-action-btn secondary meal-detail-specific-day-trigger"
                   onClick={() => setIsSpecificDayPickerOpen((previous) => !previous)}
+                  data-tour-id="meal-detail-specific-day-trigger"
                 >
                   <CalendarDays size={16} />
                   Add to a Specific Day
@@ -687,9 +842,15 @@ const MealDetail = () => {
                       value={specificDate}
                       min={todayIso}
                       onChange={handleSpecificDateChange}
+                      data-tour-id="meal-detail-specific-date-input"
                     />
                     <div className="meal-detail-specific-day-actions">
-                      <button type="button" className="specific-day-add" onClick={handleAddToSpecificDate}>
+                      <button
+                        type="button"
+                        className="specific-day-add"
+                        onClick={handleAddToSpecificDate}
+                        data-tour-id="meal-detail-specific-date-add"
+                      >
                         Add
                       </button>
                       <button
@@ -705,7 +866,12 @@ const MealDetail = () => {
               </div>
             </div>
 
-            <button type="button" className="meal-detail-view-recipe-btn" onClick={handleViewRecipe}>
+            <button
+              type="button"
+              className="meal-detail-view-recipe-btn"
+              onClick={handleViewRecipe}
+              data-tour-id="meal-detail-view-recipe-button"
+            >
               View Recipe
             </button>
           </div>
@@ -803,6 +969,14 @@ const MealDetail = () => {
           </div>
         </section>
       </div>
+
+      <GuidedTour
+        open={isMealDetailTourOpen}
+        steps={MEAL_DETAIL_TOUR_STEPS}
+        restartKey={mealDetailTourRestartKey}
+        onFinish={handleFinishMealDetailTour}
+        onSkip={handleSkipMealDetailTour}
+      />
     </div>
   );
 };

--- a/src/routes/Meal/MealRecipeDetail.css
+++ b/src/routes/Meal/MealRecipeDetail.css
@@ -15,10 +15,19 @@
 .meal-recipe-breadcrumb {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 0.625rem;
   margin-bottom: 0.875rem;
   color: #64748b;
   font-size: 0.9375rem;
+}
+
+.meal-recipe-breadcrumb-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  min-width: 0;
 }
 
 .meal-recipe-back {
@@ -34,6 +43,29 @@
 
 .meal-recipe-back:hover {
   color: #1f2937;
+}
+
+.meal-recipe-guide-btn {
+  min-height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 91, 187, 0.35);
+  background: linear-gradient(135deg, rgba(234, 242, 255, 0.96), rgba(216, 232, 255, 0.96));
+  color: #0e4f9d;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.18s ease, filter 0.18s ease, box-shadow 0.18s ease;
+}
+
+.meal-recipe-guide-btn:hover {
+  transform: translateY(-1px);
+  filter: brightness(0.98);
+  box-shadow: 0 10px 18px rgba(0, 91, 187, 0.16);
 }
 
 .meal-recipe-muted {
@@ -871,8 +903,21 @@
   }
 
   .meal-recipe-breadcrumb {
+    align-items: stretch;
     gap: 0.44rem;
     font-size: 0.8125rem;
+  }
+
+  .meal-recipe-breadcrumb-left {
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .meal-recipe-guide-btn {
+    width: 100%;
+    min-height: 2.35rem;
+    font-size: 0.85rem;
   }
 
   .meal-recipe-hero img {

--- a/src/routes/Meal/MealRecipeDetail.jsx
+++ b/src/routes/Meal/MealRecipeDetail.jsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   BarChart3,
   CalendarDays,
+  CircleHelp,
   ChevronLeft,
   Clock3,
   Cloud,
@@ -28,13 +29,66 @@ import recipeApi from "../../services/recepieApi";
 import { generateDetailedRecipe } from "../../services/aiRecipeDetailApi";
 import { getRecipes } from "../CreateRecipe/data/db/db";
 import { fetchRecipeReviews, submitRecipeReview } from "../../services/recipeReviewApi";
+import GuidedTour from "../../components/GuidedTour/GuidedTour";
 import {
   readMealSelectionsByDateFromStorage,
   writeMealSelectionsByDateToStorage,
 } from "../../utils/mealSelectionStorage";
 
 const AI_RECIPE_CACHE_STORAGE_KEY = "nutrihelp_ai_recipe_detail_cache_v1";
+const RECIPE_TOUR_STATE_KEY = "nutrihelp_recipe_detail_tour_state_v1";
 const DEFAULT_IMAGE = "/images/meal-mock/placeholder.svg";
+
+const RECIPE_TOUR_STEPS = [
+  {
+    targetId: "recipe-hero-section",
+    title: "Recipe details here",
+    description: "This page shows meal time, servings, and full recipe details.",
+    spotlightSize: 210,
+  },
+  {
+    targetId: "recipe-add-plan-button",
+    title: "Start adding this meal",
+    description: "Press Add to Meal Plan to open the planner.",
+    spotlightSize: 170,
+  },
+  {
+    targetIds: ["recipe-plan-date-input", "recipe-add-plan-button"],
+    title: "Choose a date",
+    description: "Pick the day you want this meal in your plan.",
+    spotlightSize: 195,
+  },
+  {
+    targetIds: ["recipe-slot-breakfast", "recipe-add-plan-button"],
+    title: "Choose meal time",
+    description: "Select Breakfast, Lunch, or Dinner.",
+    spotlightSize: 185,
+  },
+  {
+    targetIds: ["recipe-plan-confirm-button", "recipe-add-plan-button"],
+    title: "Save to your plan",
+    description: "Press Confirm to save this recipe to your meal plan.",
+    spotlightSize: 185,
+  },
+  {
+    targetId: "recipe-shop-ingredients-button",
+    title: "Shop ingredients",
+    description: "Use this button to prepare your shopping list quickly.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "recipe-back-button",
+    title: "Review saved meals",
+    description: "Use Back to return and review your planned meals.",
+    spotlightSize: 170,
+  },
+  {
+    targetId: "recipe-guide-button",
+    title: "Replay this guide",
+    description: "Need help again? Press Guide any time.",
+    spotlightSize: 165,
+  },
+];
 
 const MEAL_SLOT_OPTIONS = [
   { key: "breakfast", label: "Breakfast", icon: Sun, iconClass: "slot-breakfast" },
@@ -1195,6 +1249,26 @@ function writeStoredSelections(nextValue) {
   }
 }
 
+function readRecipeTourStateFromStorage() {
+  if (typeof window === "undefined") return "";
+
+  try {
+    return localStorage.getItem(RECIPE_TOUR_STATE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeRecipeTourStateToStorage(nextState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(RECIPE_TOUR_STATE_KEY, nextState);
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
+}
+
 function removeDuplicateMealSelections(selectionMap, incomingMeal) {
   if (!selectionMap || typeof selectionMap !== "object") return {};
 
@@ -1548,6 +1622,51 @@ const MealRecipeDetail = () => {
   const [selectedMealType, setSelectedMealType] = useState(() =>
     normalizePlanMealType(stateMeal?.mealType || stateMeal?.meal_type || "breakfast"),
   );
+  const [isRecipeTourOpen, setIsRecipeTourOpen] = useState(false);
+  const [recipeTourRestartKey, setRecipeTourRestartKey] = useState(0);
+  const [hasSeenRecipeTour, setHasSeenRecipeTour] = useState(false);
+  const [isRecipeTourStateReady, setIsRecipeTourStateReady] = useState(false);
+
+  const closeRecipeTour = (nextState) => {
+    setIsRecipeTourOpen(false);
+    if (!nextState) return;
+    writeRecipeTourStateToStorage(nextState);
+    setHasSeenRecipeTour(true);
+  };
+
+  const handleOpenRecipeTour = () => {
+    setIsPlannerOpen(true);
+    setIsRecipeTourOpen(true);
+    setRecipeTourRestartKey((previous) => previous + 1);
+  };
+
+  const handleFinishRecipeTour = () => {
+    closeRecipeTour("completed");
+  };
+
+  const handleSkipRecipeTour = () => {
+    closeRecipeTour("skipped");
+  };
+
+  useEffect(() => {
+    const persistedState = readRecipeTourStateFromStorage();
+    setHasSeenRecipeTour(persistedState === "completed" || persistedState === "skipped");
+    setIsRecipeTourStateReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isRecipeTourStateReady) return;
+    if (hasSeenRecipeTour) return;
+    if (isRecipeTourOpen) return;
+
+    const timerId = window.setTimeout(() => {
+      setIsPlannerOpen(true);
+      setIsRecipeTourOpen(true);
+      setRecipeTourRestartKey((previous) => previous + 1);
+    }, 450);
+
+    return () => window.clearTimeout(timerId);
+  }, [hasSeenRecipeTour, isRecipeTourOpen, isRecipeTourStateReady]);
 
   useEffect(() => {
     let isMounted = true;
@@ -1895,17 +2014,35 @@ const MealRecipeDetail = () => {
     <div className="meal-recipe-page">
       <div className="meal-recipe-shell">
         <div className="meal-recipe-breadcrumb" aria-label="breadcrumb">
-          <button type="button" className="meal-recipe-back" onClick={() => navigate(-1)}>
-            <ChevronLeft size={14} />
-            Back
+          <div className="meal-recipe-breadcrumb-left">
+            <button
+              type="button"
+              className="meal-recipe-back"
+              onClick={() => navigate(-1)}
+              data-tour-id="recipe-back-button"
+            >
+              <ChevronLeft size={14} />
+              Back
+            </button>
+            <span>/</span>
+            <span className="meal-recipe-muted">Recipes</span>
+            <span>/</span>
+            <span className="meal-recipe-current">{recipe.title}</span>
+          </div>
+
+          <button
+            type="button"
+            className="meal-recipe-guide-btn"
+            onClick={handleOpenRecipeTour}
+            data-tour-id="recipe-guide-button"
+            aria-label="Open recipe guide"
+          >
+            <CircleHelp size={17} />
+            Guide
           </button>
-          <span>/</span>
-          <span className="meal-recipe-muted">Recipes</span>
-          <span>/</span>
-          <span className="meal-recipe-current">{recipe.title}</span>
         </div>
 
-        <section className="meal-recipe-hero">
+        <section className="meal-recipe-hero" data-tour-id="recipe-hero-section">
           <img src={recipe.image} alt={recipe.title} loading="lazy" onError={handleImageError} />
           <div className="meal-recipe-hero-scrim" aria-hidden="true" />
           <div className="meal-recipe-hero-panel">
@@ -1943,6 +2080,7 @@ const MealRecipeDetail = () => {
                 type="button"
                 className="meal-recipe-pill-btn"
                 onClick={() => setIsPlannerOpen((previous) => !previous)}
+                data-tour-id="recipe-add-plan-button"
               >
                 Add to Meal Plan
                 <CalendarDays size={16} />
@@ -1959,6 +2097,7 @@ const MealRecipeDetail = () => {
                       min={todayIso}
                       value={selectedDate}
                       onChange={(event) => setSelectedDate(event.target.value)}
+                      data-tour-id="recipe-plan-date-input"
                     />
                   </div>
 
@@ -1974,6 +2113,7 @@ const MealRecipeDetail = () => {
                           aria-selected={isActive}
                           className={`meal-recipe-slot-btn ${slot.iconClass} ${isActive ? "active" : ""}`}
                           onClick={() => setSelectedMealType(slot.key)}
+                          data-tour-id={slot.key === "breakfast" ? "recipe-slot-breakfast" : undefined}
                         >
                           <Icon size={15} />
                           <span>{slot.label}</span>
@@ -1983,7 +2123,12 @@ const MealRecipeDetail = () => {
                   </div>
 
                   <div className="meal-recipe-plan-actions">
-                    <button type="button" className="confirm" onClick={handleAddToMealPlan}>
+                    <button
+                      type="button"
+                      className="confirm"
+                      onClick={handleAddToMealPlan}
+                      data-tour-id="recipe-plan-confirm-button"
+                    >
                       Confirm
                     </button>
                     <button type="button" className="close" onClick={() => setIsPlannerOpen(false)}>
@@ -2049,7 +2194,12 @@ const MealRecipeDetail = () => {
               <strong>{estimatedTotalCost === null ? "NA" : `${formatCost(estimatedTotalCost)} AUD`}</strong>
             </div>
 
-            <button type="button" className="meal-recipe-shop-btn" onClick={handleShopIngredients}>
+            <button
+              type="button"
+              className="meal-recipe-shop-btn"
+              onClick={handleShopIngredients}
+              data-tour-id="recipe-shop-ingredients-button"
+            >
               <ShoppingCart size={17} />
               Shop Ingredients
             </button>
@@ -2209,6 +2359,14 @@ const MealRecipeDetail = () => {
         {isLoading ? <p className="meal-recipe-loading">Loading recipe details...</p> : null}
         {isEnhancing ? <p className="meal-recipe-loading">Enhancing with AI for a more realistic recipe...</p> : null}
       </div>
+
+      <GuidedTour
+        open={isRecipeTourOpen}
+        steps={RECIPE_TOUR_STEPS}
+        restartKey={recipeTourRestartKey}
+        onFinish={handleFinishRecipeTour}
+        onSkip={handleSkipRecipeTour}
+      />
     </div>
   );
 };

--- a/src/routes/SearchRecipes/SearchRecipes.css
+++ b/src/routes/SearchRecipes/SearchRecipes.css
@@ -22,13 +22,47 @@
   margin: 0 auto;
 }
 
+.search-recipes-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
 .search-recipes-breadcrumb {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 24px;
   font-size: 14px;
   color: var(--ink-soft);
+  margin: 0;
+}
+
+.search-recipes-guide-btn {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid rgba(0, 91, 187, 0.26);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #0f5cc7;
+  padding: 0 16px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease, color 0.16s ease;
+  box-shadow: 0 8px 20px rgba(12, 99, 199, 0.12);
+}
+
+.search-recipes-guide-btn:hover {
+  transform: translateY(-1px);
+  background: #005bbb;
+  color: #ffffff;
+  box-shadow: 0 12px 26px rgba(0, 91, 187, 0.24);
 }
 
 .search-recipes-page .crumb-divider {
@@ -809,6 +843,15 @@
 @media (max-width: 720px) {
   .search-recipes-page {
     padding: 20px 14px 56px;
+  }
+
+  .search-recipes-topbar {
+    align-items: stretch;
+  }
+
+  .search-recipes-guide-btn {
+    width: 100%;
+    min-height: 48px;
   }
 
   .search-recipes-hero > div:first-child {

--- a/src/routes/SearchRecipes/SearchRecipes.jsx
+++ b/src/routes/SearchRecipes/SearchRecipes.jsx
@@ -1,12 +1,79 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { BarChart3, ChefHat, Clock3, Globe2, Search, Star, Users, Utensils } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { BarChart3, ChefHat, CircleHelp, Clock3, Globe2, Search, Star, Users, Utensils } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import "./SearchRecipes.css";
 import { fetchRecipeLibraryForAddMeal } from "../../services/recipeLibraryApi";
 import recipeApi from "../../services/recepieApi";
 import { fetchRecipeReviewSummaries, getRecipeReviewKey } from "../../services/recipeReviewApi";
+import GuidedTour from "../../components/GuidedTour/GuidedTour";
+import {
+  clearCrossPageTourFlow,
+  readCrossPageTourFlow,
+  setCrossPageTourFlowStage,
+} from "../../utils/crossPageTourFlow";
 
 const FALLBACK_IMAGE = "/images/meal-mock/placeholder.svg";
+const CREATE_SEARCH_TOUR_FLOW_ID = "create-to-search-recipes";
+const SEARCH_RECIPES_TOUR_STATE_KEY = "nutrihelp_search_recipes_tour_state_v1";
+
+const SEARCH_RECIPES_TOUR_STEPS = [
+  {
+    targetId: "search-recipes-hero-section",
+    title: "Welcome to Search Recipes",
+    description: "Great. Now let's find recipes quickly.",
+    spotlightSize: 220,
+  },
+  {
+    targetId: "search-recipes-search-input",
+    title: "Search here",
+    description: "Type a recipe name, meal type, or tag.",
+    spotlightSize: 210,
+  },
+  {
+    targetId: "search-recipes-all-cuisine-button",
+    title: "Filter by cuisine",
+    description: "Use these chips to narrow results.",
+    spotlightSize: 190,
+  },
+  {
+    targetIds: ["search-recipes-first-featured-card", "search-recipes-first-all-card"],
+    title: "Choose a recipe card",
+    description: "Click a card to open full recipe details.",
+    spotlightSize: 210,
+  },
+  {
+    targetId: "search-recipes-first-view-button",
+    title: "Open from View button",
+    description: "You can also press View on any recipe card.",
+    spotlightSize: 200,
+  },
+  {
+    targetId: "search-recipes-guide-button",
+    title: "Replay guide any time",
+    description: "Need help again? Press Guide here.",
+    spotlightSize: 170,
+  },
+];
+
+function readSearchRecipesTourStateFromStorage() {
+  if (typeof window === "undefined") return "";
+
+  try {
+    return localStorage.getItem(SEARCH_RECIPES_TOUR_STATE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+function writeSearchRecipesTourStateToStorage(nextState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(SEARCH_RECIPES_TOUR_STATE_KEY, nextState);
+  } catch {
+    // Ignore localStorage write failures in restricted environments.
+  }
+}
 
 function normalizeText(value) {
   return String(value || "").trim().toLowerCase();
@@ -138,6 +205,95 @@ function SearchRecipes() {
   const [error, setError] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [pageJumpInput, setPageJumpInput] = useState("");
+  const [isSearchRecipesTourOpen, setIsSearchRecipesTourOpen] = useState(false);
+  const [searchRecipesTourRestartKey, setSearchRecipesTourRestartKey] = useState(0);
+  const [hasSeenSearchRecipesTour, setHasSeenSearchRecipesTour] = useState(false);
+  const [isSearchRecipesTourStateReady, setIsSearchRecipesTourStateReady] = useState(false);
+
+  const prepareSearchRecipesTourView = useCallback(() => {
+    setRecipeSource("library");
+    setSelectedCuisine("all");
+    setSearchTerm("");
+    setSelectedRecipe(null);
+    setCurrentPage(1);
+  }, []);
+
+  const closeSearchRecipesTour = useCallback((nextState, options = {}) => {
+    const { clearFlow = false } = options;
+    setIsSearchRecipesTourOpen(false);
+
+    if (nextState) {
+      writeSearchRecipesTourStateToStorage(nextState);
+      setHasSeenSearchRecipesTour(true);
+    }
+
+    if (clearFlow) {
+      clearCrossPageTourFlow();
+    }
+  }, []);
+
+  const handleOpenSearchRecipesTour = useCallback(() => {
+    prepareSearchRecipesTourView();
+    setIsSearchRecipesTourOpen(true);
+    setSearchRecipesTourRestartKey((previous) => previous + 1);
+  }, [prepareSearchRecipesTourView]);
+
+  const handleFinishSearchRecipesTour = useCallback(() => {
+    closeSearchRecipesTour("completed", { clearFlow: true });
+  }, [closeSearchRecipesTour]);
+
+  const handleSkipSearchRecipesTour = useCallback(() => {
+    closeSearchRecipesTour("skipped", { clearFlow: true });
+  }, [closeSearchRecipesTour]);
+
+  useEffect(() => {
+    const persistedState = readSearchRecipesTourStateFromStorage();
+    setHasSeenSearchRecipesTour(persistedState === "completed" || persistedState === "skipped");
+    setIsSearchRecipesTourStateReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isSearchRecipesTourStateReady) return;
+    if (isSearchRecipesTourOpen) return;
+
+    const flow = readCrossPageTourFlow();
+    const hasPendingCrossPageFlow =
+      flow?.flowId === CREATE_SEARCH_TOUR_FLOW_ID && flow?.stage === "search-pending";
+    if (!hasPendingCrossPageFlow) return;
+
+    const timerId = window.setTimeout(() => {
+      prepareSearchRecipesTourView();
+      setCrossPageTourFlowStage(CREATE_SEARCH_TOUR_FLOW_ID, "search-started");
+      setIsSearchRecipesTourOpen(true);
+      setSearchRecipesTourRestartKey((previous) => previous + 1);
+    }, 450);
+
+    return () => window.clearTimeout(timerId);
+  }, [isSearchRecipesTourOpen, isSearchRecipesTourStateReady, prepareSearchRecipesTourView]);
+
+  useEffect(() => {
+    if (!isSearchRecipesTourStateReady) return;
+    if (hasSeenSearchRecipesTour) return;
+    if (isSearchRecipesTourOpen) return;
+
+    const flow = readCrossPageTourFlow();
+    const hasPendingCrossPageFlow =
+      flow?.flowId === CREATE_SEARCH_TOUR_FLOW_ID && flow?.stage === "search-pending";
+    if (hasPendingCrossPageFlow) return;
+
+    const timerId = window.setTimeout(() => {
+      prepareSearchRecipesTourView();
+      setIsSearchRecipesTourOpen(true);
+      setSearchRecipesTourRestartKey((previous) => previous + 1);
+    }, 500);
+
+    return () => window.clearTimeout(timerId);
+  }, [
+    hasSeenSearchRecipesTour,
+    isSearchRecipesTourOpen,
+    isSearchRecipesTourStateReady,
+    prepareSearchRecipesTourView,
+  ]);
 
   useEffect(() => {
     let isMounted = true;
@@ -296,13 +452,25 @@ function SearchRecipes() {
   return (
     <div className="search-recipes-page">
       <div className="search-recipes-shell">
-        <div className="search-recipes-breadcrumb" aria-label="breadcrumb">
-          <span className="crumb-muted">Recipe Library</span>
-          <span className="crumb-divider">/</span>
-          <span className="crumb-current">Search Recipes</span>
+        <div className="search-recipes-topbar">
+          <div className="search-recipes-breadcrumb" aria-label="breadcrumb">
+            <span className="crumb-muted">Recipe Library</span>
+            <span className="crumb-divider">/</span>
+            <span className="crumb-current">Search Recipes</span>
+          </div>
+          <button
+            type="button"
+            className="search-recipes-guide-btn"
+            onClick={handleOpenSearchRecipesTour}
+            data-tour-id="search-recipes-guide-button"
+            aria-label="Open Search Recipes guide"
+          >
+            <CircleHelp size={18} />
+            Guide
+          </button>
         </div>
 
-        <section className="search-recipes-hero">
+        <section className="search-recipes-hero" data-tour-id="search-recipes-hero-section">
           <div>
             <span className="search-recipes-kicker">
               <ChefHat size={16} />
@@ -322,7 +490,11 @@ function SearchRecipes() {
         </section>
 
         <div className="search-recipes-toolbar">
-          <label className="search-recipes-search" htmlFor="search-recipes-input">
+          <label
+            className="search-recipes-search"
+            htmlFor="search-recipes-input"
+            data-tour-id="search-recipes-search-input"
+          >
             <Search size={22} strokeWidth={2.2} className="search-icon" />
             <input
               id="search-recipes-input"
@@ -357,6 +529,7 @@ function SearchRecipes() {
               type="button"
               className={`cuisine-chip ${selectedCuisine === "all" ? "active" : ""}`}
               onClick={() => handleCuisineClick("all")}
+              data-tour-id="search-recipes-all-cuisine-button"
             >
               <Globe2 size={15} />
               All cuisines
@@ -387,11 +560,12 @@ function SearchRecipes() {
             <section className="search-recipes-section">
               <h2 className="section-title">Featured Recipes</h2>
               <div className="search-recommended-row">
-                {featuredRecipes.map((recipe) => (
+                {featuredRecipes.map((recipe, index) => (
                   <article
                     key={`featured-${recipe.id}`}
                     className="search-recommend-card"
                     onClick={() => handleViewRecipe(recipe)}
+                    data-tour-id={index === 0 ? "search-recipes-first-featured-card" : undefined}
                   >
                     <div className="search-recommend-image">
                       <img src={recipe.image || FALLBACK_IMAGE} alt={recipe.title} loading="lazy" onError={handleImageError} />
@@ -421,7 +595,7 @@ function SearchRecipes() {
               </div>
 
               <div className="search-recipes-grid">
-                {paginatedRecipes.map((recipe) => (
+                {paginatedRecipes.map((recipe, index) => (
                   <article
                     key={recipe.id}
                     className={`search-recipe-card ${selectedRecipe?.id === recipe.id ? "selected" : ""}`}
@@ -429,6 +603,7 @@ function SearchRecipes() {
                       setSelectedRecipe(recipe);
                       handleViewRecipe(recipe);
                     }}
+                    data-tour-id={index === 0 ? "search-recipes-first-all-card" : undefined}
                   >
                     <div className="search-recipe-image">
                       <img src={recipe.image || FALLBACK_IMAGE} alt={recipe.title} loading="lazy" onError={handleImageError} />
@@ -467,6 +642,7 @@ function SearchRecipes() {
                           setSelectedRecipe(recipe);
                           handleViewRecipe(recipe);
                         }}
+                        data-tour-id={index === 0 ? "search-recipes-first-view-button" : undefined}
                       >
                         View
                       </button>
@@ -544,6 +720,14 @@ function SearchRecipes() {
           </aside>
         ) : null}
       </div>
+
+      <GuidedTour
+        open={isSearchRecipesTourOpen}
+        steps={SEARCH_RECIPES_TOUR_STEPS}
+        restartKey={searchRecipesTourRestartKey}
+        onFinish={handleFinishSearchRecipesTour}
+        onSkip={handleSkipSearchRecipesTour}
+      />
     </div>
   );
 }

--- a/src/utils/crossPageTourFlow.js
+++ b/src/utils/crossPageTourFlow.js
@@ -1,0 +1,45 @@
+const CROSS_PAGE_TOUR_FLOW_STORAGE_KEY = "nutrihelp_cross_page_tour_flow_v1";
+
+export function readCrossPageTourFlow() {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = sessionStorage.getItem(CROSS_PAGE_TOUR_FLOW_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCrossPageTourFlow(nextFlowState) {
+  if (typeof window === "undefined") return;
+
+  try {
+    sessionStorage.setItem(CROSS_PAGE_TOUR_FLOW_STORAGE_KEY, JSON.stringify(nextFlowState));
+  } catch {
+    // Ignore sessionStorage write failures in restricted environments.
+  }
+}
+
+export function clearCrossPageTourFlow() {
+  if (typeof window === "undefined") return;
+
+  try {
+    sessionStorage.removeItem(CROSS_PAGE_TOUR_FLOW_STORAGE_KEY);
+  } catch {
+    // Ignore sessionStorage write failures in restricted environments.
+  }
+}
+
+export function setCrossPageTourFlowStage(flowId, stage, extras = {}) {
+  if (!flowId || !stage) return;
+
+  writeCrossPageTourFlow({
+    flowId,
+    stage,
+    ...extras,
+    updatedAt: Date.now(),
+  });
+}


### PR DESCRIPTION
This commit introduces a reusable, on-screen guided tour system to help users complete key NutriHelp actions directly in the real interface, with a strong focus on clarity and accessibility for non-technical and elderly users.

What this commit adds

1) Reusable Guided Tour infrastructure
- Added a new reusable component:
  - src/components/GuidedTour/GuidedTour.jsx
  - src/components/GuidedTour/GuidedTour.css
- Supports step-based tours with:
  - circular spotlight highlight
  - pulsing/glowing animation
  - pointer/click icon near target
  - dimmed background overlay
  - Next, Back, Skip, Finish controls
- Targets elements by stable selectors/data attributes:
  - targetId / targetIds
  - targetSelector / targetSelectors
- Automatically updates spotlight position on:
  - scroll
  - window resize
  - target size changes (ResizeObserver)
- Auto-scrolls target into view for each step.

2) Persistent tour state
- Each page stores completed/skipped state in localStorage so first-time auto-show is only shown once.
- Added utility for cross-page tour continuation:
  - src/utils/crossPageTourFlow.js
- Cross-page handoff state is stored in sessionStorage:
  - flow id + stage + timestamp
- This enables seamless continuation from Create Recipe to Search Recipes.

3) Add Meal flow guidance
- Integrated full Add Meal tutorial in:
  - src/routes/Meal/Meal.jsx
  - src/routes/Meal/Meal.css
- Added Guide replay button and tour anchors (data-tour-id) for key actions:
  - open Add Meal tab
  - choose date
  - choose meal slot
  - search meals
  - select meal card
  - verify selected count
  - review saved meal plan

4) Meal Detail guidance
- Added guided tour and replay button in:
  - src/routes/Meal/MealDetail.jsx
  - src/routes/Meal/MealDetail.css
- Covers meal detail actions such as meal slot selection, add for today/another day, date confirmation, and recipe navigation.

5) Recipe Detail guidance
- Added guided tour and replay button in:
  - src/routes/Meal/MealRecipeDetail.jsx
  - src/routes/Meal/MealRecipeDetail.css
- Covers recipe detail actions such as opening add-to-plan flow, choosing date/meal time, saving to plan, ingredient shopping, and navigation.

6) Create Recipe guidance + cross-page continuation
- Added guided tour and replay button in:
  - src/routes/CreateRecipe/CreateRecipe.jsx
  - src/routes/CreateRecipe/CreateRecipe.css
- Step flow covers:
  - recipe name
  - cuisine
  - add ingredient
  - add instruction
  - save recipe
- On Finish, the tour sets cross-page flow stage and navigates to Search Recipes to continue guidance.

7) Search Recipes guidance
- Added guided tour and replay button in:
  - src/routes/SearchRecipes/SearchRecipes.jsx
  - src/routes/SearchRecipes/SearchRecipes.css
- Step flow covers:
  - page hero
  - search input
  - cuisine filter
  - recipe card selection
  - View button
  - replay Guide button
- Supports both:
  - first-time auto-show
  - auto-open when arriving from Create Recipe cross-page flow.

Behavior and safety
- Existing business logic for meal/recipe creation and selection is preserved.
- Changes are UI-guidance focused and non-destructive.
- Manual replay always works, even after completed/skipped state is saved.
 
<img width="1728" height="997" alt="Screenshot 2026-05-18 at 16 44 09" src="https://github.com/user-attachments/assets/ce80d3a0-a853-4d65-b2ee-be331637370c" />
