### PR TITLE
CS-1: Add privacy policy and signup consent flow

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ import { UserContext } from "./context/user.context";
 
 import Login from "./routes/Login/Login";
 import SignUp from "./routes/SignUp/SignUp";
+import PrivacyPolicy from "./routes/PrivacyPolicy/PrivacyPolicy";
 import ForgotPassword from "./routes/ForgotPassword/ForgotPassword";
 import ForgotPasswordVerify from "./routes/ForgotPassword/ForgotPasswordVerify";
 import ForgotPasswordReset from "./routes/ForgotPassword/ForgotPasswordReset";
@@ -159,6 +160,7 @@ function App() {
         {/* PUBLIC ROUTES */}
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<SignUp />} />
+        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
 
 
         {/* Forgot password flow */}

--- a/src/components/MainNavbar.js
+++ b/src/components/MainNavbar.js
@@ -198,7 +198,7 @@ const MainNavbar = () => {
           {/* Left */}
           <div className="nav-left">
             <Link to="/home" className="nav-link">
-              Home TEST
+              Home
             </Link>
 
             <Link to="/scan" className="nav-link nav-link-icon">

--- a/src/components/MainNavbar.js
+++ b/src/components/MainNavbar.js
@@ -198,7 +198,7 @@ const MainNavbar = () => {
           {/* Left */}
           <div className="nav-left">
             <Link to="/home" className="nav-link">
-              Home
+              Home TEST
             </Link>
 
             <Link to="/scan" className="nav-link nav-link-icon">

--- a/src/routes/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/src/routes/PrivacyPolicy/PrivacyPolicy.jsx
@@ -1,0 +1,84 @@
+import { useNavigate } from "react-router-dom";
+
+export default function PrivacyPolicy() {
+  const navigate = useNavigate();
+
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        backgroundColor: "#f5f5f5",
+        padding: "40px 20px",
+        fontFamily: '"Poppins", sans-serif',
+      }}
+    >
+      <section
+        style={{
+          maxWidth: "850px",
+          margin: "0 auto",
+          backgroundColor: "white",
+          padding: "36px",
+          borderRadius: "20px",
+          boxShadow: "0 8px 30px rgba(0,0,0,0.12)",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          style={{
+            border: "none",
+            background: "none",
+            cursor: "pointer",
+            textDecoration: "underline",
+            marginBottom: "20px",
+            fontSize: "15px",
+          }}
+        >
+          Back
+        </button>
+
+        <h1>NutriHelp Privacy Policy</h1>
+        <p>
+          This policy explains what personal information NutriHelp collects,
+          why it is collected, and how it is protected.
+        </p>
+
+        <h2>Information we collect</h2>
+        <p>
+          NutriHelp may collect your name, contact details, dietary
+          preferences, allergies, health information, meal plans, and other
+          information you choose to provide.
+        </p>
+
+        <h2>Why we collect it</h2>
+        <p>
+          We use this information to provide personalised nutrition guidance,
+          meal planning, food-safety warnings, and other NutriHelp features.
+        </p>
+
+        <h2>How we protect it</h2>
+        <p>
+          NutriHelp uses access controls, encryption, secure connections, and
+          security monitoring to help protect your information.
+        </p>
+
+        <h2>Your choices</h2>
+        <p>
+          You can review and update your account information. You may also ask
+          for support regarding your personal information through the
+          NutriHelp contact form.
+        </p>
+
+        <h2>Consent</h2>
+        <p>
+          By creating an account and selecting the consent checkbox, you
+          confirm that you have read and agreed to this privacy policy.
+        </p>
+
+        <p>
+          <strong>Policy version:</strong> 1.0
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/routes/SignUp/SignUp.jsx
+++ b/src/routes/SignUp/SignUp.jsx
@@ -23,6 +23,14 @@ export default function SignUp() {
   const [serverError, setServerError] = useState("");
 
   const handleGoogleSignup = async () => {
+    if (!form.privacyConsent) {
+      setErrors({
+        privacyConsent:
+          "You must agree to the Privacy Policy before creating an account.",
+      });
+      return;
+    }
+
     const { error } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
@@ -34,7 +42,7 @@ export default function SignUp() {
       setServerError(error.message);
     }
   };
-
+  
   const handleAppleSignup = async () => {
     const message = "Apple sign-in is not configured in this sprint build yet.";
     setServerError(message);

--- a/src/routes/SignUp/SignUp.jsx
+++ b/src/routes/SignUp/SignUp.jsx
@@ -60,6 +60,11 @@ export default function SignUp() {
     const phoneErr = validatePhone(values.phone);
     if (phoneErr) err.phone = phoneErr;
 
+    if (!values.privacyConsent) {
+      err.privacyConsent =
+        "You must agree to the Privacy Policy before creating an account.";
+    }
+
     return err;
   };
 
@@ -80,6 +85,7 @@ export default function SignUp() {
       phone: "",
       password: "",
       confirmPassword: "",
+      privacyConsent: false,
     },
     validate,
     async (values) => {
@@ -549,6 +555,34 @@ export default function SignUp() {
                 />
               </div>
             </div>
+
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                marginTop: "6px",
+                marginBottom: "10px",
+              }}
+            >
+              <input
+                type="checkbox"
+                id="privacyConsent"
+                name="privacyConsent"
+                checked={form.privacyConsent}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              />
+
+              <label htmlFor="privacyConsent" style={{ fontSize: "14px" }}>
+                I agree to the Privacy Policy
+              </label>
+            </div>
+
+            <FieldError
+              error={errors.privacyConsent}
+              touched={touched.privacyConsent}
+            />
 
             {serverError && (
               <p style={{ ...styles.error, marginTop: 8 }}>{serverError}</p>

--- a/src/routes/SignUp/SignUp.jsx
+++ b/src/routes/SignUp/SignUp.jsx
@@ -93,13 +93,16 @@ export default function SignUp() {
       try {
         const payload = {
           name: `${values.firstName} ${values.lastName}`.trim(),
+          first_name: values.firstName.trim(),
+          last_name: values.lastName.trim(),
           email: values.email.trim().toLowerCase(),
           password: values.password,
           contact_number: values.phone || "0412345678",
           address: "Placeholder address 123",
+          privacy_consent: values.privacyConsent,
         };
 
-        const res = await fetch(`${API_BASE_URL}/api/signup`, {
+        const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),

--- a/src/routes/SignUp/SignUp.jsx
+++ b/src/routes/SignUp/SignUp.jsx
@@ -169,7 +169,12 @@ export default function SignUp() {
               }
             }
 
-            msg = data.error || data.message || msg;
+            msg =
+              (typeof data.error === "string"
+                ? data.error
+                : data.error?.message) ||
+              data.message ||
+              msg;
           } catch {
             if (text) msg = text;
           }
@@ -187,7 +192,13 @@ export default function SignUp() {
         }
 
         const data = await parseJsonSafe(res);
-        setServerError(data.error || `Sign up failed (HTTP ${res.status})`);
+        setServerError(
+          (typeof data.error === "string"
+            ? data.error
+            : data.error?.message) ||
+          data.message ||
+          `Sign up failed (HTTP ${res.status})`,
+        );
       } catch (error) {
         console.error("Sign up request failed:", error);
         setServerError(

--- a/src/routes/SignUp/SignUp.jsx
+++ b/src/routes/SignUp/SignUp.jsx
@@ -578,7 +578,14 @@ export default function SignUp() {
               />
 
               <label htmlFor="privacyConsent" style={{ fontSize: "14px" }}>
-                I agree to the Privacy Policy
+                I have read and agree to the{" "}
+                <a
+                  href="/privacy-policy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Privacy Policy
+                </a>
               </label>
             </div>
 


### PR DESCRIPTION
## Summary

Implements the frontend portion of CS-1 Privacy Policy & Consent Flow.

## Changes

- Added a plain-language privacy policy page at `/privacy-policy`
- Added a mandatory privacy consent checkbox to the signup form
- Blocked normal registration until consent is provided
- Blocked Google signup until consent is provided
- Linked the consent text to the privacy policy in a new tab
- Updated the registration request to send `privacy_consent`
- Added safe handling for structured backend registration errors

## Testing

- Confirmed the privacy policy page loads correctly
- Confirmed signup is blocked when the consent checkbox is unticked
- Confirmed the privacy policy link opens correctly
- Confirmed checked consent is sent to the API
- Confirmed backend database errors display without crashing the page

## Related backend work

A separate API pull request contains consent validation, storage logic, and the SQL migration for the consent timestamp and policy version.

The database migration has not yet been applied to Supabase and requires review.